### PR TITLE
Use Google eventId on cancel/reschedule

### DIFF
--- a/controllers/dialogflowWebhookController.js
+++ b/controllers/dialogflowWebhookController.js
@@ -264,7 +264,8 @@ router.post("/webhook", async (req, res) => {
 
             try {
               const result = await cancelarAgendamento(
-                agendamentoPendente.agendamentoId
+                agendamentoPendente.agendamentoId,
+                agendamentoPendente.eventId
               );
               console.log("Resultado de cancelarAgendamento:", result);
 
@@ -640,6 +641,7 @@ router.post("/webhook", async (req, res) => {
             agendamentosPendentes.set(from, {
               clienteId: cliente.id,
               agendamentoId: agendamento.id,
+              eventId: agendamento.google_event_id,
               servico: agendamento.servico,
               confirmationStep: "confirmar_inicio_reagendamento",
             });
@@ -703,6 +705,7 @@ router.post("/webhook", async (req, res) => {
             agendamentosPendentes.set(from, {
               ...agendamentoPendente,
               agendamentoId: agendamentoEscolhido.id,
+              eventId: agendamentoEscolhido.google_event_id,
               servico: agendamentoEscolhido.servico,
               confirmationStep: "awaiting_reagendamento_datahora",
               agendamentosAtivos: undefined, // Limpa agendamentosAtivos para evitar uso incorreto
@@ -895,7 +898,8 @@ router.post("/webhook", async (req, res) => {
           if (isConfirmation) {
             const result = await reagendarAgendamento(
               agendamentoPendente.agendamentoId,
-              agendamentoPendente.dia_horario
+              agendamentoPendente.dia_horario,
+              agendamentoPendente.eventId
             );
 
             if (!result.success) {
@@ -1014,6 +1018,7 @@ router.post("/webhook", async (req, res) => {
             agendamentosPendentes.set(from, {
               clienteId: cliente.id,
               agendamentoId: agendamento.id,
+              eventId: agendamento.google_event_id,
               servico: agendamento.servico,
               confirmationStep: "confirmar_cancelamento",
             });
@@ -1061,6 +1066,7 @@ router.post("/webhook", async (req, res) => {
             agendamentosPendentes.set(from, {
               ...agendamentoPendente,
               agendamentoId: agendamentoEscolhido.id,
+              eventId: agendamentoEscolhido.google_event_id,
               servico: agendamentoEscolhido.servico,
               confirmationStep: "confirmar_cancelamento",
               agendamentosAtivos: undefined, // Limpa agendamentosAtivos

--- a/controllers/gerenciamentoController.js
+++ b/controllers/gerenciamentoController.js
@@ -5,26 +5,31 @@ const {
   criarAgendamento,
 } = require("../services/calendarService");
 
-async function cancelarAgendamento(agendamentoId) {
+async function cancelarAgendamento(agendamentoId, googleEventId) {
   const connection = await pool.getConnection();
   try {
     await connection.beginTransaction();
 
-    const [agendamento] = await connection.query(
-      'SELECT google_event_id FROM agendamentos WHERE id = ? AND status = "ativo"',
-      [agendamentoId]
-    );
+    let eventId = googleEventId;
+    if (!eventId) {
+      const [agendamento] = await connection.query(
+        'SELECT google_event_id FROM agendamentos WHERE id = ? AND status = "ativo"',
+        [agendamentoId]
+      );
 
-    if (!agendamento || agendamento.length === 0) {
-      await connection.release();
-      return {
-        success: false,
-        message: "Agendamento não encontrado ou já cancelado.",
-      };
+      if (!agendamento || agendamento.length === 0) {
+        await connection.release();
+        return {
+          success: false,
+          message: "Agendamento não encontrado ou já cancelado.",
+        };
+      }
+
+      eventId = agendamento[0].google_event_id;
     }
 
     try {
-      await cancelarEvento(agendamento[0].google_event_id);
+      await cancelarEvento(eventId);
     } catch (e) {
       console.error("Erro ao cancelar evento no Google Calendar:", e);
     }
@@ -63,24 +68,28 @@ async function listarAgendamentosAtivos(clienteId) {
   }
 }
 
-async function reagendarAgendamento(agendamentoId, novoHorario) {
+async function reagendarAgendamento(agendamentoId, novoHorario, googleEventId) {
   try {
     await pool.query("START TRANSACTION");
 
-    const [agendamento] = await pool.query(
-      'SELECT google_event_id FROM agendamentos WHERE id = ? AND status = "ativo"',
-      [agendamentoId]
-    );
-    if (!agendamento.length) {
-      await pool.query("ROLLBACK");
-      return {
-        success: false,
-        message: "Agendamento não encontrado ou já cancelado.",
-      };
+    let eventId = googleEventId;
+    if (!eventId) {
+      const [agendamento] = await pool.query(
+        'SELECT google_event_id FROM agendamentos WHERE id = ? AND status = "ativo"',
+        [agendamentoId]
+      );
+      if (!agendamento.length) {
+        await pool.query("ROLLBACK");
+        return {
+          success: false,
+          message: "Agendamento não encontrado ou já cancelado.",
+        };
+      }
+      eventId = agendamento[0].google_event_id;
     }
 
     try {
-      await cancelarEvento(agendamento[0].google_event_id);
+      await cancelarEvento(eventId);
     } catch (e) {
       console.error("Erro ao cancelar evento antigo no Google Calendar:", e);
     }


### PR DESCRIPTION
## Summary
- allow `cancelarAgendamento` and `reagendarAgendamento` to receive the Google Calendar event ID
- store `google_event_id` in pending state during cancel/reagendar flows
- pass the event ID to cancellation and reschedule operations

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c7a19936083278cd0b3d1b5befb93