### PR TITLE
Add google_event_id support

### DIFF
--- a/bd.sql
+++ b/bd.sql
@@ -62,3 +62,7 @@ INSERT INTO servicos (nome, descricao, duracao) VALUES
 ('Barba', 'Modelagem e aparo de barba', '00:30:00'),
 ('Corte + Barba', 'Corte e modelagem de barba', '01:00:00');
 
+-- Garante compatibilidade com bancos existentes
+ALTER TABLE agendamentos
+    ADD COLUMN IF NOT EXISTS google_event_id VARCHAR(255) NOT NULL;
+

--- a/controllers/agendamentoController.js
+++ b/controllers/agendamentoController.js
@@ -4,6 +4,18 @@ const {
   criarAgendamento,
 } = require("../services/calendarService");
 
+// Garante que a coluna google_event_id exista na tabela de agendamentos
+async function ensureGoogleEventIdColumn() {
+  const [rows] = await pool.query(
+    "SHOW COLUMNS FROM agendamentos LIKE 'google_event_id'"
+  );
+  if (rows.length === 0) {
+    await pool.query(
+      "ALTER TABLE agendamentos ADD COLUMN google_event_id VARCHAR(255)"
+    );
+  }
+}
+
 async function buscarHorariosDisponiveis(data) {
   try {
     const horarios = await listarHorariosDisponiveis(data);
@@ -16,6 +28,7 @@ async function buscarHorariosDisponiveis(data) {
 
 async function agendarServico({ clienteId, clienteNome, servicoNome, horario }) {
   try {
+    await ensureGoogleEventIdColumn();
     if (!clienteId || !horario) {
       return { success: false, message: "Cliente ou horário inválido." };
     }


### PR DESCRIPTION
## Summary
- ensure `google_event_id` column exists in `agendamentos`
- add SQL migration step
- store Google Calendar event ID when saving appointments

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c7c43e6488327b6f6629d8ae4215b