### PR TITLE
Add global error middleware

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,7 +145,7 @@ async function listarTodosHorariosDisponiveis(dias = 7) {
 }
 
 // --- Rota Principal do Webhook ---
-app.post("/webhook", async (req, res) => {
+app.post("/webhook", async (req, res, next) => {
   const msg = req.body.Body || req.body.text;
   const from = req.body.From || req.body.sessionId;
   const profileName = req.body.ProfileName || "Cliente";
@@ -1100,10 +1100,16 @@ app.post("/webhook", async (req, res) => {
     console.log("Resposta FINAL a ser enviada ao usuário:", resposta);
     res.json({ reply: resposta });
   } catch (error) {
-    // Captura erros globais do webhook
+    // Propaga erros não tratados para o middleware global
     console.error("ERRO GERAL no Dialogflow ou webhook:", error);
-    res.json({ reply: "Ops, algo deu errado. Tente novamente?" });
+    next(error);
   }
+});
+
+// Middleware global de tratamento de erros
+app.use((err, req, res, next) => {
+  console.error('Unhandled error:', err);
+  res.status(500).json({ error: 'Ops, algo deu errado. Tente novamente mais tarde.' });
 });
 
 app.listen(port, () => {

--- a/routes/agendamentoRoutes.js
+++ b/routes/agendamentoRoutes.js
@@ -5,7 +5,7 @@ const { buscarHorariosDisponiveis, agendarServico } = require('../controllers/ag
 const { cancelarAgendamento } = require('../controllers/gerenciamentoController');
 
 // Lista horários disponíveis para uma data (YYYY-MM-DD)
-router.get('/horarios', async (req, res) => {
+router.get('/horarios', async (req, res, next) => {
   const { data } = req.query;
   if (!data) {
     return res.status(400).json({ error: 'Parâmetro "data" é obrigatório' });
@@ -15,25 +15,23 @@ router.get('/horarios', async (req, res) => {
     const horarios = await buscarHorariosDisponiveis(data);
     res.json({ horarios });
   } catch (err) {
-    console.error('Erro ao buscar horários:', err);
-    res.status(500).json({ error: 'Erro ao buscar horários disponíveis' });
+    next(err);
   }
 });
 
 // Agenda um serviço
-router.post('/agendar', async (req, res) => {
+router.post('/agendar', async (req, res, next) => {
   const { clienteId, clienteNome, servicoNome, horario } = req.body;
   try {
     const resultado = await agendarServico({ clienteId, clienteNome, servicoNome, horario });
     res.json(resultado);
   } catch (err) {
-    console.error('Erro ao agendar serviço:', err);
-    res.status(500).json({ error: 'Erro ao agendar serviço' });
+    next(err);
   }
 });
 
 // Cancela um agendamento
-router.post('/cancelar', async (req, res) => {
+router.post('/cancelar', async (req, res, next) => {
   const { agendamentoId, googleEventId } = req.body;
   if (!agendamentoId) {
     return res.status(400).json({ error: 'agendamentoId é obrigatório' });
@@ -43,8 +41,7 @@ router.post('/cancelar', async (req, res) => {
     const resultado = await cancelarAgendamento(agendamentoId, googleEventId);
     res.json(resultado);
   } catch (err) {
-    console.error('Erro ao cancelar agendamento:', err);
-    res.status(500).json({ error: 'Erro ao cancelar agendamento' });
+    next(err);
   }
 });
 

--- a/routes/clienteRoutes.js
+++ b/routes/clienteRoutes.js
@@ -4,7 +4,7 @@ const router = express.Router();
 const { encontrarOuCriarCliente, atualizarNomeCliente } = require('../controllers/clienteController');
 
 // Cria ou retorna cliente existente a partir do telefone
-router.post('/buscar-ou-criar', async (req, res) => {
+router.post('/buscar-ou-criar', async (req, res, next) => {
   const { telefone, profileName } = req.body;
   if (!telefone) {
     return res.status(400).json({ error: 'telefone é obrigatório' });
@@ -13,13 +13,12 @@ router.post('/buscar-ou-criar', async (req, res) => {
     const cliente = await encontrarOuCriarCliente(telefone, profileName);
     res.json(cliente);
   } catch (err) {
-    console.error('Erro ao buscar/criar cliente:', err);
-    res.status(500).json({ error: 'Erro ao buscar ou criar cliente' });
+    next(err);
   }
 });
 
 // Atualiza o nome de um cliente
-router.put('/:id/nome', async (req, res) => {
+router.put('/:id/nome', async (req, res, next) => {
   const { id } = req.params;
   const { nome } = req.body;
   if (!nome) {
@@ -32,8 +31,7 @@ router.put('/:id/nome', async (req, res) => {
     }
     res.json(cliente);
   } catch (err) {
-    console.error('Erro ao atualizar cliente:', err);
-    res.status(500).json({ error: 'Erro ao atualizar cliente' });
+    next(err);
   }
 });
 


### PR DESCRIPTION
## Summary
- propagate controller errors with `next`
- add Express error handler middleware

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c80e589708327a8d77d53d9eecf68