### PR TITLE
Add input validation and error handling

### DIFF
--- a/controllers/agendamentoController.js
+++ b/controllers/agendamentoController.js
@@ -3,6 +3,11 @@ const {
   listarHorariosDisponiveis,
   criarAgendamento,
 } = require("../services/calendarService");
+const {
+  isValidServico,
+  isValidDataHora,
+} = require("../utils/validation");
+const { ValidationError } = require("../utils/errors");
 
 // Garante que a coluna google_event_id exista na tabela de agendamentos
 async function ensureGoogleEventIdColumn() {
@@ -17,6 +22,9 @@ async function ensureGoogleEventIdColumn() {
 }
 
 async function buscarHorariosDisponiveis(data) {
+  if (!isValidDataHora(data)) {
+    throw new ValidationError("Data inválida");
+  }
   try {
     const horarios = await listarHorariosDisponiveis(data);
     return horarios;
@@ -27,11 +35,17 @@ async function buscarHorariosDisponiveis(data) {
 }
 
 async function agendarServico({ clienteId, clienteNome, servicoNome, horario }) {
+  if (!clienteId || isNaN(parseInt(clienteId))) {
+    return { success: false, message: "ID do cliente inválido." };
+  }
+  if (!isValidServico(servicoNome)) {
+    return { success: false, message: "Serviço inválido." };
+  }
+  if (!isValidDataHora(horario)) {
+    return { success: false, message: "Data e hora inválidas." };
+  }
   try {
     await ensureGoogleEventIdColumn();
-    if (!clienteId || !horario) {
-      return { success: false, message: "Cliente ou horário inválido." };
-    }
 
     const evento = await criarAgendamento({
       cliente: clienteNome,

--- a/controllers/clienteController.js
+++ b/controllers/clienteController.js
@@ -1,9 +1,20 @@
 const pool = require("../db");
+const {
+  isValidTelefone,
+  isValidNome,
+} = require("../utils/validation");
+const { ValidationError } = require("../utils/errors");
 
 // Encontra ou cria um cliente no banco de dados.
 // Se o cliente existir, ele é retornado. Se não, um novo é criado.
 // Tenta usar profileName do Twilio, se disponível.
 async function encontrarOuCriarCliente(telefone, profileName = "Cliente") {
+  if (!isValidTelefone(telefone)) {
+    throw new ValidationError("Telefone inválido");
+  }
+  if (profileName && !isValidNome(profileName)) {
+    throw new ValidationError("Nome inválido");
+  }
   let client;
   try {
     client = await pool.getConnection();
@@ -54,6 +65,9 @@ async function encontrarOuCriarCliente(telefone, profileName = "Cliente") {
 
 // Atualiza o nome de um cliente existente.
 async function atualizarNomeCliente(clienteId, novoNome) {
+  if (!isValidNome(novoNome)) {
+    throw new ValidationError("Nome inválido");
+  }
   let client;
   console.log("aqui");
 

--- a/controllers/gerenciamentoController.js
+++ b/controllers/gerenciamentoController.js
@@ -4,6 +4,8 @@ const {
   cancelarAgendamento: cancelarEvento,
   criarAgendamento,
 } = require("../services/calendarService");
+const { isValidDataHora } = require("../utils/validation");
+const { ValidationError } = require("../utils/errors");
 
 async function cancelarAgendamento(agendamentoId, googleEventId) {
   const connection = await pool.getConnection();
@@ -52,6 +54,9 @@ async function cancelarAgendamento(agendamentoId, googleEventId) {
 
 // Resto do arquivo permanece igual
 async function listarAgendamentosAtivos(clienteId) {
+  if (!clienteId || isNaN(parseInt(clienteId))) {
+    throw new ValidationError("ID do cliente inválido");
+  }
   try {
     const [rows] = await pool.query(
       `SELECT a.id, a.google_event_id, a.horario, s.nome AS servico
@@ -69,6 +74,9 @@ async function listarAgendamentosAtivos(clienteId) {
 }
 
 async function reagendarAgendamento(agendamentoId, novoHorario, googleEventId) {
+  if (!isValidDataHora(novoHorario)) {
+    return { success: false, message: "Data e hora inválidas." };
+  }
   try {
     await pool.query("START TRANSACTION");
 

--- a/index.js
+++ b/index.js
@@ -1109,7 +1109,9 @@ app.post("/webhook", async (req, res, next) => {
 // Middleware global de tratamento de erros
 app.use((err, req, res, next) => {
   console.error('Unhandled error:', err);
-  res.status(500).json({ error: 'Ops, algo deu errado. Tente novamente mais tarde.' });
+  const status = err.status || 500;
+  const message = err.message || 'Ops, algo deu errado. Tente novamente mais tarde.';
+  res.status(status).json({ error: message });
 });
 
 app.listen(port, () => {

--- a/routes/agendamentoRoutes.js
+++ b/routes/agendamentoRoutes.js
@@ -3,6 +3,7 @@ const router = express.Router();
 
 const { buscarHorariosDisponiveis, agendarServico } = require('../controllers/agendamentoController');
 const { cancelarAgendamento } = require('../controllers/gerenciamentoController');
+const { ValidationError } = require('../utils/errors');
 
 // Lista horários disponíveis para uma data (YYYY-MM-DD)
 router.get('/horarios', async (req, res, next) => {
@@ -15,6 +16,9 @@ router.get('/horarios', async (req, res, next) => {
     const horarios = await buscarHorariosDisponiveis(data);
     res.json({ horarios });
   } catch (err) {
+    if (err instanceof ValidationError) {
+      return res.status(400).json({ error: err.message });
+    }
     next(err);
   }
 });
@@ -24,8 +28,14 @@ router.post('/agendar', async (req, res, next) => {
   const { clienteId, clienteNome, servicoNome, horario } = req.body;
   try {
     const resultado = await agendarServico({ clienteId, clienteNome, servicoNome, horario });
+    if (!resultado.success) {
+      return res.status(400).json({ error: resultado.message });
+    }
     res.json(resultado);
   } catch (err) {
+    if (err instanceof ValidationError) {
+      return res.status(400).json({ error: err.message });
+    }
     next(err);
   }
 });

--- a/routes/clienteRoutes.js
+++ b/routes/clienteRoutes.js
@@ -2,6 +2,7 @@ const express = require('express');
 const router = express.Router();
 
 const { encontrarOuCriarCliente, atualizarNomeCliente } = require('../controllers/clienteController');
+const { ValidationError } = require('../utils/errors');
 
 // Cria ou retorna cliente existente a partir do telefone
 router.post('/buscar-ou-criar', async (req, res, next) => {
@@ -13,6 +14,9 @@ router.post('/buscar-ou-criar', async (req, res, next) => {
     const cliente = await encontrarOuCriarCliente(telefone, profileName);
     res.json(cliente);
   } catch (err) {
+    if (err instanceof ValidationError) {
+      return res.status(400).json({ error: err.message });
+    }
     next(err);
   }
 });
@@ -31,6 +35,9 @@ router.put('/:id/nome', async (req, res, next) => {
     }
     res.json(cliente);
   } catch (err) {
+    if (err instanceof ValidationError) {
+      return res.status(400).json({ error: err.message });
+    }
     next(err);
   }
 });

--- a/utils/errors.js
+++ b/utils/errors.js
@@ -1,0 +1,9 @@
+class ValidationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'ValidationError';
+    this.status = 400;
+  }
+}
+
+module.exports = { ValidationError };

--- a/utils/validation.js
+++ b/utils/validation.js
@@ -1,0 +1,50 @@
+// Utility validation functions for controller inputs
+
+/**
+ * Validate Brazilian phone number. Accepts digits with optional leading '+'.
+ * @param {string} telefone
+ * @returns {boolean}
+ */
+function isValidTelefone(telefone) {
+  if (typeof telefone !== 'string') return false;
+  // remove spaces and symbols
+  const digits = telefone.replace(/\D/g, '');
+  // typically 10 to 13 digits including country code
+  return /^\d{10,13}$/.test(digits);
+}
+
+/**
+ * Validate that name is a non-empty string
+ * @param {string} nome
+ * @returns {boolean}
+ */
+function isValidNome(nome) {
+  return typeof nome === 'string' && nome.trim().length > 0;
+}
+
+/**
+ * Validate that service is a non-empty string
+ * @param {string} servico
+ * @returns {boolean}
+ */
+function isValidServico(servico) {
+  return typeof servico === 'string' && servico.trim().length > 0;
+}
+
+/**
+ * Validate date/time string in ISO format
+ * @param {string} dataHora
+ * @returns {boolean}
+ */
+function isValidDataHora(dataHora) {
+  if (typeof dataHora !== 'string') return false;
+  const date = new Date(dataHora);
+  return !isNaN(date.getTime());
+}
+
+module.exports = {
+  isValidTelefone,
+  isValidNome,
+  isValidServico,
+  isValidDataHora,
+};


### PR DESCRIPTION
## Summary
- validate incoming data for phone, name, service and dates
- add utility helpers for validation and errors
- return HTTP 400 on invalid data

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c821ae7408327a06c280bdcfd55a9