### PR TITLE
Add origin validation middleware

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ const {
 } = require("./controllers/gerenciamentoController");
 const logger = require("./utils/logger");
 const mensagens = require("./utils/mensagensUsuario");
+const originValidator = require("./middlewares/originValidator");
 
 const app = express();
 const port = 3000;
@@ -56,7 +57,7 @@ const SERVICOS_VALIDOS = {
 };
 
 // --- Rota Principal do Webhook ---
-app.post("/webhook", async (req, res, next) => {
+app.post("/webhook", originValidator, async (req, res, next) => {
   const msg = req.body.Body || req.body.text;
   const from = req.body.From || req.body.sessionId;
   const profileName = req.body.ProfileName || "Cliente";

--- a/middlewares/originValidator.js
+++ b/middlewares/originValidator.js
@@ -1,0 +1,9 @@
+const allowedAgents = [/Twilio/i, /Dialogflow/i];
+
+module.exports = function originValidator(req, res, next) {
+  const userAgent = req.get('user-agent') || '';
+  if (allowedAgents.some(pattern => pattern.test(userAgent))) {
+    return next();
+  }
+  return res.status(403).json({ error: 'Origem nao autorizada' });
+};


### PR DESCRIPTION
## Summary
- add middleware to restrict webhook origins to known agents
- apply middleware on `/webhook` route

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c8b3d48e08327b8a75fa97d851834