### PR TITLE
Standardize API response format

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,11 @@ Resposta esperada:
 
 ```json
 {
-  "reply": "Mensagem de resposta gerada pelo bot"
+  "success": true,
+  "data": {
+    "reply": "Mensagem de resposta gerada pelo bot"
+  },
+  "message": null
 }
 ```
 
@@ -42,8 +46,11 @@ Resposta esperada:
 ```json
 {
   "success": true,
-  "agendamentoId": 42,
-  "eventId": "abcdef123456"
+  "data": {
+    "agendamentoId": 42,
+    "eventId": "abcdef123456"
+  },
+  "message": "Agendamento realizado com sucesso"
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ const {
 const logger = require("./utils/logger");
 const mensagens = require("./utils/mensagensUsuario");
 const originValidator = require("./middlewares/originValidator");
+const { createResponse } = require("./utils/apiResponse");
 
 const app = express();
 const port = process.env.PORT || 3000;
@@ -134,7 +135,7 @@ app.post("/webhook", originValidator, async (req, res, next) => {
               "awaiting_reagendamento_datahora";
             agendamentosPendentes.set(from, estadoAgendamentoPendente);
             processamentoConcluido = true;
-            res.json({ reply: resposta });
+            res.json(createResponse(true, { reply: resposta }, null));
             return;
           }
           break;
@@ -983,7 +984,7 @@ app.post("/webhook", originValidator, async (req, res, next) => {
       }
     }
     logger.info("Resposta FINAL a ser enviada ao usuário:", resposta);
-    res.json({ reply: resposta });
+    res.json(createResponse(true, { reply: resposta }, null));
   } catch (error) {
     // Propaga erros não tratados para o middleware global
     logger.error("ERRO GERAL no Dialogflow ou webhook:", error);
@@ -996,7 +997,7 @@ app.use((err, req, res, next) => {
   logger.error('Unhandled error:', err);
   const status = err.status || 500;
   const message = err.message || mensagens.ERRO_GERAL;
-  res.status(status).json({ error: message });
+  res.status(status).json(createResponse(false, null, message));
 });
 
 app.listen(port, () => {

--- a/middlewares/originValidator.js
+++ b/middlewares/originValidator.js
@@ -1,9 +1,12 @@
 const allowedAgents = [/Twilio/i, /Dialogflow/i];
+const { createResponse } = require("../utils/apiResponse");
 
 module.exports = function originValidator(req, res, next) {
-  const userAgent = req.get('user-agent') || '';
-  if (allowedAgents.some(pattern => pattern.test(userAgent))) {
+  const userAgent = req.get("user-agent") || "";
+  if (allowedAgents.some((pattern) => pattern.test(userAgent))) {
     return next();
   }
-  return res.status(403).json({ error: 'Origem nao autorizada' });
+  return res
+    .status(403)
+    .json(createResponse(false, null, "Origem nao autorizada"));
 };

--- a/routes/agendamentoRoutes.js
+++ b/routes/agendamentoRoutes.js
@@ -1,23 +1,29 @@
 const express = require('express');
 const router = express.Router();
 
-const { buscarHorariosDisponiveis, agendarServico } = require('../controllers/agendamentoController');
-const { cancelarAgendamento } = require('../controllers/gerenciamentoController');
-const { ValidationError } = require('../utils/errors');
+const {
+  buscarHorariosDisponiveis,
+  agendarServico,
+} = require("../controllers/agendamentoController");
+const { cancelarAgendamento } = require("../controllers/gerenciamentoController");
+const { ValidationError } = require("../utils/errors");
+const { createResponse } = require("../utils/apiResponse");
 
 // Lista horários disponíveis para uma data (YYYY-MM-DD)
 router.get('/horarios', async (req, res, next) => {
   const { data } = req.query;
   if (!data) {
-    return res.status(400).json({ error: 'Parâmetro "data" é obrigatório' });
+    return res
+      .status(400)
+      .json(createResponse(false, null, 'Parâmetro "data" é obrigatório'));
   }
 
   try {
     const horarios = await buscarHorariosDisponiveis(data);
-    res.json({ horarios });
+    res.json(createResponse(true, horarios, "Horários disponíveis"));
   } catch (err) {
     if (err instanceof ValidationError) {
-      return res.status(400).json({ error: err.message });
+      return res.status(400).json(createResponse(false, null, err.message));
     }
     next(err);
   }
@@ -27,14 +33,24 @@ router.get('/horarios', async (req, res, next) => {
 router.post('/agendar', async (req, res, next) => {
   const { clienteId, clienteNome, servicoNome, horario } = req.body;
   try {
-    const resultado = await agendarServico({ clienteId, clienteNome, servicoNome, horario });
+    const resultado = await agendarServico({
+      clienteId,
+      clienteNome,
+      servicoNome,
+      horario,
+    });
     if (!resultado.success) {
-      return res.status(400).json({ error: resultado.message });
+      return res.status(400).json(createResponse(false, null, resultado.message));
     }
-    res.json(resultado);
+    res.json(
+      createResponse(true, {
+        agendamentoId: resultado.agendamentoId,
+        eventId: resultado.eventId,
+      }, "Agendamento realizado com sucesso")
+    );
   } catch (err) {
     if (err instanceof ValidationError) {
-      return res.status(400).json({ error: err.message });
+      return res.status(400).json(createResponse(false, null, err.message));
     }
     next(err);
   }
@@ -44,12 +60,17 @@ router.post('/agendar', async (req, res, next) => {
 router.post('/cancelar', async (req, res, next) => {
   const { agendamentoId, googleEventId } = req.body;
   if (!agendamentoId) {
-    return res.status(400).json({ error: 'agendamentoId é obrigatório' });
+    return res
+      .status(400)
+      .json(createResponse(false, null, "agendamentoId é obrigatório"));
   }
 
   try {
     const resultado = await cancelarAgendamento(agendamentoId, googleEventId);
-    res.json(resultado);
+    if (!resultado.success) {
+      return res.status(400).json(createResponse(false, null, resultado.message));
+    }
+    res.json(createResponse(true, null, "Agendamento cancelado"));
   } catch (err) {
     next(err);
   }

--- a/routes/clienteRoutes.js
+++ b/routes/clienteRoutes.js
@@ -1,21 +1,29 @@
 const express = require('express');
 const router = express.Router();
 
-const { encontrarOuCriarCliente, atualizarNomeCliente } = require('../controllers/clienteController');
-const { ValidationError } = require('../utils/errors');
+const {
+  encontrarOuCriarCliente,
+  atualizarNomeCliente,
+} = require("../controllers/clienteController");
+const { ValidationError } = require("../utils/errors");
+const { createResponse } = require("../utils/apiResponse");
 
 // Cria ou retorna cliente existente a partir do telefone
 router.post('/buscar-ou-criar', async (req, res, next) => {
   const { telefone, profileName } = req.body;
   if (!telefone) {
-    return res.status(400).json({ error: 'telefone é obrigatório' });
+    return res
+      .status(400)
+      .json(createResponse(false, null, "telefone é obrigatório"));
   }
   try {
     const cliente = await encontrarOuCriarCliente(telefone, profileName);
-    res.json(cliente);
+    res.json(
+      createResponse(true, cliente, "Cliente encontrado ou criado com sucesso")
+    );
   } catch (err) {
     if (err instanceof ValidationError) {
-      return res.status(400).json({ error: err.message });
+      return res.status(400).json(createResponse(false, null, err.message));
     }
     next(err);
   }
@@ -26,17 +34,21 @@ router.put('/:id/nome', async (req, res, next) => {
   const { id } = req.params;
   const { nome } = req.body;
   if (!nome) {
-    return res.status(400).json({ error: 'nome é obrigatório' });
+    return res
+      .status(400)
+      .json(createResponse(false, null, "nome é obrigatório"));
   }
   try {
     const cliente = await atualizarNomeCliente(id, nome);
     if (!cliente) {
-      return res.status(404).json({ error: 'Cliente não encontrado' });
+      return res
+        .status(404)
+        .json(createResponse(false, null, "Cliente não encontrado"));
     }
-    res.json(cliente);
+    res.json(createResponse(true, cliente, "Nome atualizado com sucesso"));
   } catch (err) {
     if (err instanceof ValidationError) {
-      return res.status(400).json({ error: err.message });
+      return res.status(400).json(createResponse(false, null, err.message));
     }
     next(err);
   }

--- a/utils/apiResponse.js
+++ b/utils/apiResponse.js
@@ -1,0 +1,5 @@
+function createResponse(success, data = null, message = null) {
+  return { success, data, message };
+}
+
+module.exports = { createResponse };


### PR DESCRIPTION
## Summary
- add `createResponse` utility
- enforce consistent JSON format in API routes and middleware
- update webhook and error handler to use `createResponse`
- document new response formats in README

## Testing
- `npm test --silent` *(fails: calendarService, gerenciamentoController)*

------
https://chatgpt.com/codex/tasks/task_e_68502116d09883278aab7c9c8e043da0