### PR TITLE
Add global rate limiting

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ const {
 const logger = require("./utils/logger");
 const mensagens = require("./utils/mensagensUsuario");
 const originValidator = require("./middlewares/originValidator");
+const rateLimiter = require("./middlewares/rateLimiter");
 const { createResponse } = require("./utils/apiResponse");
 
 const app = express();
@@ -38,6 +39,7 @@ const agendamentosPendentes = new Map();
 
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(bodyParser.json());
+app.use(rateLimiter);
 
 const agendamentoRoutes = require("./routes/agendamentoRoutes");
 const clienteRoutes = require("./routes/clienteRoutes");

--- a/middlewares/rateLimiter.js
+++ b/middlewares/rateLimiter.js
@@ -1,0 +1,10 @@
+const rateLimit = require('express-rate-limit');
+
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+  standardHeaders: true, // return rate limit info in the `RateLimit-*` headers
+  legacyHeaders: false, // disable the `X-RateLimit-*` headers
+});
+
+module.exports = limiter;

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@google-cloud/dialogflow": "^7.0.1",
     "body-parser": "^2.2.0",
+    "express-rate-limit": "^6.11.0",
     "dotenv": "^16.4.5",
     "express": "^5.1.0",
     "express-session": "^1.18.1",


### PR DESCRIPTION
## Summary
- add rate limit middleware using `express-rate-limit`
- apply middleware in `index.js`
- declare new dependency in `package.json`

## Testing
- `npm test` *(fails: 3 failed, 3 total)*

------
https://chatgpt.com/codex/tasks/task_e_685023eac5a48327aa7d3aef80292437