### PR TITLE
Add trust proxy setting for proper rate limit behind proxies

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ const rateLimiter = require("./middlewares/rateLimiter");
 const { createResponse } = require("./utils/apiResponse");
 
 const app = express();
+app.set('trust proxy', 1);
 const port = process.env.PORT || 3000;
 
 // Configuração do Dialogflow


### PR DESCRIPTION
## Summary
- ensure Express trusts X-Forwarded-For by enabling `trust proxy`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850285d4ef883278193dd89fdbef464