### PR TITLE
Fix calendar ID constant

### DIFF
--- a/__tests__/calendarService.test.js
+++ b/__tests__/calendarService.test.js
@@ -10,7 +10,6 @@ jest.mock('googleapis', () => {
 });
 
 const { __eventsMock } = require('googleapis');
-process.env.CALENDAR_ID = 'cal1';
 const calendarService = require('../services/calendarService');
 
 describe('calendarService', () => {
@@ -46,6 +45,10 @@ describe('calendarService', () => {
   test('cancelarAgendamento chama events.delete', async () => {
     __eventsMock.delete.mockResolvedValue();
     await calendarService.cancelarAgendamento('ev456');
-    expect(__eventsMock.delete).toHaveBeenCalledWith({ calendarId: process.env.CALENDAR_ID, eventId: 'ev456' });
+    expect(__eventsMock.delete).toHaveBeenCalledWith({
+      calendarId:
+        '99435b27c68a7a48eca3aa3ab9770b8d0207851464d88c89e55c763bfca69c0a@group.calendar.google.com',
+      eventId: 'ev456',
+    });
   });
 });

--- a/services/calendarService.js
+++ b/services/calendarService.js
@@ -2,7 +2,9 @@ require("dotenv").config();
 const { google } = require("googleapis");
 const path = require("path");
 
-const CALENDAR_ID = process.env.CALENDAR_ID; // ID do calendário exclusivo do bot
+// ID fixo do calendário utilizado pelo bot
+const CALENDAR_ID =
+  "99435b27c68a7a48eca3aa3ab9770b8d0207851464d88c89e55c763bfca69c0a@group.calendar.google.com";
 const TIME_ZONE = "America/Sao_Paulo";
 
 // Configura autenticação usando a conta de serviço


### PR DESCRIPTION
## Summary
- set `CALENDAR_ID` constant to the production calendar id
- update calendar service tests for the new constant

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68503299a07c8327bfdd2f04431a8a5a