### PR TITLE
Implement input validation for scheduling

### DIFF
--- a/__tests__/agendamentoController.test.js
+++ b/__tests__/agendamentoController.test.js
@@ -29,13 +29,13 @@ describe('agendamentoController', () => {
       clienteId: 1,
       clienteNome: 'Jose',
       servicosNomes: ['corte', 'barba'],
-      horario: '2024-01-01T09:00:00-03:00'
+      horario: '2030-01-01T09:00:00-03:00'
     });
 
     expect(calendarService.criarAgendamento).toHaveBeenCalledWith({
       cliente: 'Jose',
       servicos: ['corte', 'barba'],
-      horario: '2024-01-01T09:00:00-03:00'
+      horario: '2030-01-01T09:00:00-03:00'
     });
     expect(resp).toEqual({ success: true, agendamentoId: 7, eventId: 'e1' });
   });

--- a/controllers/agendamentoController.js
+++ b/controllers/agendamentoController.js
@@ -6,6 +6,7 @@ const {
 const {
   isValidServico,
   isValidDataHora,
+  isValidNome,
 } = require("../utils/validation");
 const { ValidationError } = require("../utils/errors");
 
@@ -23,7 +24,7 @@ async function ensureGoogleEventIdColumn() {
 }
 
 async function buscarHorariosDisponiveis(data) {
-  if (!isValidDataHora(data)) {
+  if (isNaN(new Date(data).getTime())) {
     throw new ValidationError("Data inválida");
   }
   try {
@@ -46,6 +47,13 @@ async function agendarServico({
   if (!clienteId || isNaN(parseInt(clienteId))) {
     return { success: false, message: "ID do cliente inválido." };
   }
+  if (clienteNome && !isValidNome(clienteNome)) {
+    return {
+      success: false,
+      message:
+        "O nome deve possuir ao menos 3 letras e conter apenas caracteres alfabéticos.",
+    };
+  }
   // Permite string separada por vírgulas ou array de nomes
   let servicos = [];
   if (Array.isArray(servicosNomes)) {
@@ -57,10 +65,18 @@ async function agendarServico({
   }
   servicos = servicos.map((s) => s.trim()).filter((s) => s);
   if (!servicos.length || !servicos.every(isValidServico)) {
-    return { success: false, message: "Serviço inválido." };
+    return {
+      success: false,
+      message:
+        "O serviço selecionado é inválido. Escolha entre 'Corte', 'Barba' ou 'Corte + Barba'.",
+    };
   }
   if (!isValidDataHora(horario)) {
-    return { success: false, message: "Data e hora inválidas." };
+    return {
+      success: false,
+      message:
+        "Data e hora inválidas. Use o formato DD/MM/YYYY HH:mm e escolha um horário futuro.",
+    };
   }
   try {
     await ensureGoogleEventIdColumn();

--- a/controllers/clienteController.js
+++ b/controllers/clienteController.js
@@ -10,10 +10,14 @@ const logger = require("../utils/logger");
 // Tenta usar profileName do Twilio, se disponível.
 async function encontrarOuCriarCliente(telefone, profileName = "Cliente") {
   if (!isValidTelefone(telefone)) {
-    throw new ValidationError("Telefone inválido");
+    throw new ValidationError(
+      "O número de telefone deve estar no formato +55DDDDDDDDDDD."
+    );
   }
   if (profileName && !isValidNome(profileName)) {
-    throw new ValidationError("Nome inválido");
+    throw new ValidationError(
+      "O nome deve possuir ao menos 3 letras e conter apenas caracteres alfabéticos."
+    );
   }
   let client;
   try {
@@ -67,7 +71,9 @@ async function encontrarOuCriarCliente(telefone, profileName = "Cliente") {
 // Atualiza o nome de um cliente existente.
 async function atualizarNomeCliente(clienteId, novoNome) {
   if (!isValidNome(novoNome)) {
-    throw new ValidationError("Nome inválido");
+    throw new ValidationError(
+      "O nome deve possuir ao menos 3 letras e conter apenas caracteres alfabéticos."
+    );
   }
   let client;
   logger.info("aqui");

--- a/controllers/gerenciamentoController.js
+++ b/controllers/gerenciamentoController.js
@@ -79,7 +79,11 @@ async function listarAgendamentosAtivos(clienteId) {
 
 async function reagendarAgendamento(agendamentoId, novoHorario, googleEventId) {
   if (!isValidDataHora(novoHorario)) {
-    return { success: false, message: "Data e hora inválidas." };
+    return {
+      success: false,
+      message:
+        "Data e hora inválidas. Use o formato DD/MM/YYYY HH:mm e escolha um horário futuro.",
+    };
   }
   try {
     await pool.query("START TRANSACTION");

--- a/utils/validation.js
+++ b/utils/validation.js
@@ -6,11 +6,11 @@
  * @returns {boolean}
  */
 function isValidTelefone(telefone) {
-  if (typeof telefone !== 'string') return false;
-  // remove spaces and symbols
-  const digits = telefone.replace(/\D/g, '');
-  // typically 10 to 13 digits including country code
-  return /^\d{10,13}$/.test(digits);
+  if (typeof telefone !== "string") return false;
+  // Remove caracteres opcionais como espacos, hifens e parenteses
+  const normalized = telefone.replace(/[\s()-]/g, "");
+  // Deve comecar com +55 seguido de 2 digitos de DDD e 9 digitos do numero
+  return /^\+55\d{11}$/.test(normalized);
 }
 
 /**
@@ -19,7 +19,11 @@ function isValidTelefone(telefone) {
  * @returns {boolean}
  */
 function isValidNome(nome) {
-  return typeof nome === 'string' && nome.trim().length > 0;
+  if (typeof nome !== "string") return false;
+  const trimmed = nome.trim();
+  return (
+    trimmed.length >= 3 && /^[A-Za-zÀ-ÖØ-öø-ÿ\s]+$/.test(trimmed)
+  );
 }
 
 /**
@@ -27,8 +31,11 @@ function isValidNome(nome) {
  * @param {string} servico
  * @returns {boolean}
  */
+const SERVICOS_VALIDOS = ["Corte", "Barba", "Corte + Barba"];
 function isValidServico(servico) {
-  return typeof servico === 'string' && servico.trim().length > 0;
+  if (typeof servico !== "string") return false;
+  const normalized = servico.trim().toLowerCase();
+  return SERVICOS_VALIDOS.some((s) => s.toLowerCase() === normalized);
 }
 
 /**
@@ -36,10 +43,35 @@ function isValidServico(servico) {
  * @param {string} dataHora
  * @returns {boolean}
  */
+function isValidFutureDate(dataStr, horaStr) {
+  if (!/^\d{2}\/\d{2}\/\d{4}$/.test(dataStr)) return false;
+  if (!/^\d{2}:\d{2}$/.test(horaStr)) return false;
+  const [dia, mes, ano] = dataStr.split("/");
+  const [h, m] = horaStr.split(":");
+  const dt = new Date(`${ano}-${mes}-${dia}T${h}:${m}:00`);
+  return !isNaN(dt.getTime()) && dt > new Date();
+}
+
 function isValidDataHora(dataHora) {
-  if (typeof dataHora !== 'string') return false;
-  const date = new Date(dataHora);
-  return !isNaN(date.getTime());
+  if (typeof dataHora === "string") {
+    if (/^\d{2}\/\d{2}\/\d{4}\s\d{2}:\d{2}$/.test(dataHora)) {
+      const [data, hora] = dataHora.split(" ");
+      return isValidFutureDate(data, hora);
+    }
+    const date = new Date(dataHora);
+    return !isNaN(date.getTime()) && date > new Date();
+  }
+
+  if (
+    dataHora &&
+    typeof dataHora === "object" &&
+    typeof dataHora.data === "string" &&
+    typeof dataHora.hora === "string"
+  ) {
+    return isValidFutureDate(dataHora.data, dataHora.hora);
+  }
+
+  return false;
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary
- enforce stronger validation rules in `utils/validation`
- return informative validation errors in controllers
- adjust unit tests to use future dates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685070ad91d083278ea0d1f853e70448