### PR TITLE
Filtrar domingos nos dias disponíveis

### DIFF
--- a/utils/dataHelpers.js
+++ b/utils/dataHelpers.js
@@ -70,14 +70,22 @@ function getDateFromWeekdayAndTime(diaSemanaStr, horaStr) {
 async function listarTodosHorariosDisponiveis(dias = 7) {
   const horarios = [];
   const hoje = new Date();
-  for (let i = 0; i < dias; i++) {
+  let adicionados = 0;
+  let offset = 0;
+  while (adicionados < dias) {
     const data = new Date(hoje);
-    data.setDate(hoje.getDate() + i);
+    data.setDate(hoje.getDate() + offset);
+    offset++;
+    // Ignora domingos (getDay() === 0)
+    if (data.getDay() === 0) {
+      continue;
+    }
     const dataStr = data.toISOString().slice(0, 10);
     const horas = await listarHorariosDisponiveis(dataStr);
     for (const hora of horas) {
       horarios.push({ dia_horario: `${dataStr}T${hora}:00` });
     }
+    adicionados++;
   }
   return horarios;
 }


### PR DESCRIPTION
## Summary
- skip Sundays in `listarTodosHorariosDisponiveis`
- adjust day pagination automatically to list only Monday–Saturday

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685079758b048327841013a1019e35a2