### PR TITLE
Filter out Sunday times from calendar

### DIFF
--- a/__tests__/calendarService.test.js
+++ b/__tests__/calendarService.test.js
@@ -31,6 +31,12 @@ describe('calendarService', () => {
     expect(horarios).toContain('13:30');
   });
 
+  test('listarHorariosDisponiveis ignora domingos', async () => {
+    __eventsMock.list.mockResolvedValue({ data: { items: [] } });
+    const horarios = await calendarService.listarHorariosDisponiveis('2024-01-07');
+    expect(horarios).toEqual([]);
+  });
+
   test('criarAgendamento repassa dados ao googleapis', async () => {
     __eventsMock.insert.mockResolvedValue({ data: { id: 'ev123' } });
     const dados = { cliente: 'Ana', servicos: ['Corte', 'Barba'], horario: '2024-01-01T09:00:00-03:00' };

--- a/services/calendarService.js
+++ b/services/calendarService.js
@@ -54,7 +54,14 @@ async function listarHorariosDisponiveis(data) {
     }
   }
 
-  return disponiveis;
+  // Remove quaisquer horários que caiam em domingo
+  const filtrados = disponiveis.filter((h) => {
+    const dt = new Date(`${ano}-${mes}-${dia}T${h}:00-03:00`);
+    const day = dt.getDay();
+    return day >= 1 && day <= 6;
+  });
+
+  return filtrados;
 }
 
 /**


### PR DESCRIPTION
## Summary
- exclude Sunday slots when listing available hours
- test that available hours for Sunday return an empty array

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68507b6e47388327a49e09f13bb83e69