### PR TITLE
Filtra domingos no bot

### DIFF
--- a/index.js
+++ b/index.js
@@ -349,6 +349,11 @@ app.post("/webhook", originValidator, async (req, res, next) => {
             if (dataParam) {
               const p = new Date(dataParam);
               if (!isNaN(p.getTime())) {
+                if (p.getDay() === 0) {
+                  resposta = mensagens.DOMINGO_NAO_PERMITIDO;
+                  agendamentosPendentes.set(from, agendamentoPendente);
+                  break;
+                }
                 const dataStr = p.toISOString().slice(0, 10);
                 if (diasKeys.includes(dataStr)) {
                   escolhido = dataStr;
@@ -357,6 +362,11 @@ app.post("/webhook", originValidator, async (req, res, next) => {
             }
             if (!escolhido && parametros?.dia_semana?.stringValue) {
               const diaParam = parametros.dia_semana.stringValue.toLowerCase();
+              if ("domingo".startsWith(diaParam)) {
+                resposta = mensagens.DOMINGO_NAO_PERMITIDO;
+                agendamentosPendentes.set(from, agendamentoPendente);
+                break;
+              }
               escolhido = diasKeys.find((k) => {
                 const nome = new Date(k)
                   .toLocaleDateString("pt-BR", { weekday: "long" })
@@ -436,6 +446,11 @@ app.post("/webhook", originValidator, async (req, res, next) => {
             }
 
             if (dataSolicitada && !isNaN(dataSolicitada.getTime())) {
+              if (dataSolicitada.getDay() === 0) {
+                resposta = mensagens.DOMINGO_NAO_PERMITIDO;
+                agendamentosPendentes.set(from, agendamentoPendente);
+                break;
+              }
               const diaDaSemanaFormatado = dataSolicitada
                 .toLocaleDateString("pt-BR", { weekday: "long" })
                 .toLowerCase();
@@ -840,6 +855,11 @@ app.post("/webhook", originValidator, async (req, res, next) => {
             }
 
             if (dataSolicitada && !isNaN(dataSolicitada.getTime())) {
+              if (dataSolicitada.getDay() === 0) {
+                resposta = mensagens.DOMINGO_NAO_PERMITIDO;
+                agendamentosPendentes.set(from, agendamentoPendente);
+                break;
+              }
               const diaDaSemanaFormatado = dataSolicitada
                 .toLocaleDateString("pt-BR", { weekday: "long" })
                 .toLowerCase();

--- a/utils/mensagensUsuario.js
+++ b/utils/mensagensUsuario.js
@@ -9,6 +9,8 @@ const MENSAGENS = {
     "Escolha um serviço antes (Corte, Barba ou Sobrancelha). Qual prefere?",
   SEM_HORARIOS_DISPONIVEIS:
     "Não temos horários disponíveis no momento. Tente novamente mais tarde!",
+  DOMINGO_NAO_PERMITIDO:
+    "Desculpe, não agendamos aos domingos. Escolha um dia de segunda a sábado.",
   NAO_AGENDAMENTO_ANDAMENTO:
     "Nenhum agendamento em andamento ou etapa incorreta. Quer agendar um serviço?",
   NAO_ESPERANDO_NOME:


### PR DESCRIPTION
## Summary
- add DOMINGO_NAO_PERMITIDO message
- impede seleção de domingo ao escolher dia
- valida domingo ao informar data e hora

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685082be99208327ac68d5b7da6b411c