### PR TITLE
Add Portuguese date parser

### DIFF
--- a/__tests__/respostaParser.test.js
+++ b/__tests__/respostaParser.test.js
@@ -1,0 +1,29 @@
+const { parseEscolhaDia, DEFAULT_ERROR_MSG } = require('../utils/respostaParser');
+
+describe('parseEscolhaDia', () => {
+  test('reconhece dia da semana', () => {
+    const res = parseEscolhaDia('Terça');
+    expect(res).toEqual({ type: 'weekday', value: 2 });
+  });
+
+  test('reconhece data dd/mm', () => {
+    const year = new Date().getFullYear();
+    const res = parseEscolhaDia('05/07');
+    expect(res).toEqual({ type: 'date', value: `${year}-07-05` });
+  });
+
+  test('reconhece data completa', () => {
+    const res = parseEscolhaDia('12/10/2025');
+    expect(res).toEqual({ type: 'date', value: '2025-10-12' });
+  });
+
+  test('reconhece ver mais dias', () => {
+    const res = parseEscolhaDia('Ver mais dias');
+    expect(res).toEqual({ type: 'verMais' });
+  });
+
+  test('retorna erro para entrada invalida', () => {
+    const res = parseEscolhaDia('xyz');
+    expect(res).toEqual({ type: 'invalid', error: DEFAULT_ERROR_MSG });
+  });
+});

--- a/index.js
+++ b/index.js
@@ -29,6 +29,11 @@ const mensagens = require("./utils/mensagensUsuario");
 const originValidator = require("./middlewares/originValidator");
 const rateLimiter = require("./middlewares/rateLimiter");
 const { createResponse } = require("./utils/apiResponse");
+const {
+  parseEscolhaDia,
+  DEFAULT_ERROR_MSG,
+  removeAccents,
+} = require("./utils/respostaParser");
 
 const app = express();
 app.set('trust proxy', 1);
@@ -374,6 +379,41 @@ app.post("/webhook", originValidator, async (req, res, next) => {
                   .toLowerCase();
                 return nome.startsWith(diaParam);
               });
+            }
+            if (!escolhido) {
+              const parsed = parseEscolhaDia(msg);
+              if (parsed.type === "verMais") {
+                agendamentoPendente.diaIndex += 6;
+              } else if (parsed.type === "date") {
+                if (diasKeys.includes(parsed.value)) {
+                  escolhido = parsed.value;
+                }
+              } else if (parsed.type === "weekday") {
+                const dias = [
+                  "domingo",
+                  "segunda",
+                  "terça",
+                  "quarta",
+                  "quinta",
+                  "sexta",
+                  "sábado",
+                ];
+                const dayName = dias[parsed.value];
+                escolhido = diasKeys.find((k) => {
+                  const nome = new Date(k)
+                    .toLocaleDateString("pt-BR", { weekday: "long" })
+                    .replace("-feira", "")
+                    .toLowerCase();
+                  return (
+                    removeAccents(nome).startsWith(removeAccents(dayName)) ||
+                    nome.startsWith(dayName)
+                  );
+                });
+              } else if (parsed.type === "invalid") {
+                resposta = DEFAULT_ERROR_MSG;
+                agendamentosPendentes.set(from, agendamentoPendente);
+                break;
+              }
             }
             if (escolhido) {
               agendamentoPendente.diaEscolhido = escolhido;

--- a/utils/respostaParser.js
+++ b/utils/respostaParser.js
@@ -1,0 +1,36 @@
+const DEFAULT_ERROR_MSG = "Desculpe, não entendi. Por favor, responda com o nome do dia, a data (ex: 20/06) ou digite 'Ver mais dias' para mais opções.";
+
+function removeAccents(str) {
+  return str.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+}
+
+function parseEscolhaDia(input) {
+  if (!input || typeof input !== 'string') {
+    return { type: 'invalid', error: DEFAULT_ERROR_MSG };
+  }
+  const text = input.trim().toLowerCase();
+  if (text === 'ver mais dias') {
+    return { type: 'verMais' };
+  }
+
+  const dataMatch = text.match(/^(\d{1,2})\/(\d{1,2})(?:\/(\d{4}))?$/);
+  if (dataMatch) {
+    let [, d, m, a] = dataMatch;
+    const year = a || String(new Date().getFullYear());
+    d = d.padStart(2, '0');
+    m = m.padStart(2, '0');
+    return { type: 'date', value: `${year}-${m}-${d}` };
+  }
+
+  const dias = ['domingo', 'segunda', 'terça', 'quarta', 'quinta', 'sexta', 'sábado'];
+  const normalized = removeAccents(text);
+  for (let i = 0; i < dias.length; i++) {
+    if (removeAccents(dias[i]).startsWith(normalized)) {
+      return { type: 'weekday', value: i };
+    }
+  }
+
+  return { type: 'invalid', error: DEFAULT_ERROR_MSG };
+}
+
+module.exports = { parseEscolhaDia, DEFAULT_ERROR_MSG, removeAccents };


### PR DESCRIPTION
## Summary
- create `respostaParser` to parse days of week, dates and "Ver mais dias"
- integrate parser into the scheduling flow
- test parser logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685176df8ab48327a516ee97db8b10ce