### PR TITLE
Block Sunday scheduling

### DIFF
--- a/controllers/dialogflowWebhookController.js
+++ b/controllers/dialogflowWebhookController.js
@@ -22,6 +22,7 @@ const {
   reagendarAgendamento,
 } = require("./gerenciamentoController");
 const logger = require("../utils/logger");
+const mensagens = require("../utils/mensagensUsuario");
 
 const router = express.Router();
 
@@ -331,7 +332,7 @@ router.post("/webhook", async (req, res) => {
               const p = new Date(dataParam);
               if (!isNaN(p.getTime())) {
                 if (p.getDay() === 0) {
-                  resposta = "Não agendamos aos domingos. Escolha outro dia.";
+                  resposta = mensagens.DOMINGO_NAO_PERMITIDO;
                   agendamentosPendentes.set(from, agendamentoPendente);
                   break;
                 }
@@ -344,7 +345,7 @@ router.post("/webhook", async (req, res) => {
             if (!escolhido && parametros?.dia_semana?.stringValue) {
               const diaParam = parametros.dia_semana.stringValue.toLowerCase();
               if ("domingo".startsWith(diaParam)) {
-                resposta = "Não agendamos aos domingos. Escolha outro dia.";
+                resposta = mensagens.DOMINGO_NAO_PERMITIDO;
                 agendamentosPendentes.set(from, agendamentoPendente);
                 break;
               }
@@ -759,6 +760,12 @@ router.post("/webhook", async (req, res) => {
             }
 
             if (dataSolicitada && !isNaN(dataSolicitada.getTime())) {
+              if (dataSolicitada.getDay() === 0) {
+                resposta = mensagens.DOMINGO_NAO_PERMITIDO;
+                agendamentosPendentes.set(from, agendamentoPendente);
+                break;
+              }
+
               const diaDaSemanaFormatado = dataSolicitada
                 .toLocaleDateString("pt-BR", { weekday: "long" })
                 .toLowerCase();

--- a/utils/mensagensUsuario.js
+++ b/utils/mensagensUsuario.js
@@ -10,7 +10,7 @@ const MENSAGENS = {
   SEM_HORARIOS_DISPONIVEIS:
     "Não temos horários disponíveis no momento. Tente novamente mais tarde!",
   DOMINGO_NAO_PERMITIDO:
-    "Desculpe, não agendamos aos domingos. Escolha um dia de segunda a sábado.",
+    "Não realizamos agendamentos aos domingos. Escolha um dia entre segunda e sábado.",
   HORARIO_INVALIDO:
     "Horário inválido. Escolha um dos horários disponíveis listados acima.",
   NAO_AGENDAMENTO_ANDAMENTO:


### PR DESCRIPTION
## Summary
- prevent Sunday scheduling with unified message
- import and use that message in the Dialogflow webhook
- update scheduler logic to reject Sundays

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68517f6e53c8832793f03b96ffbb356b