### PR TITLE
Implement detailed logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 reservai_twilio.json
 package-lock.json
 barbearia-calendar.json
+logs/

--- a/controllers/agendamentoController.js
+++ b/controllers/agendamentoController.js
@@ -46,8 +46,7 @@ async function buscarHorariosDisponiveis(data) {
     const horarios = await listarHorariosDisponiveis(data);
     return horarios;
   } catch (error) {
-    console.error('Erro:', error, error && error.stack, JSON.stringify(error));
-    logger.error("Erro ao buscar horários disponíveis:", error);
+    logger.error(null, error);
     throw new Error("Erro ao buscar horários disponíveis.");
   }
 }
@@ -127,8 +126,7 @@ async function agendarServico({
 
     return { success: true, agendamentoId, eventId: evento.id };
   } catch (error) {
-    console.error('Erro:', error, error && error.stack, JSON.stringify(error));
-    logger.error("Erro ao agendar serviço:", error);
+    logger.error(null, error);
     return {
       success: false,
       message: mensagens.ERRO_AGENDAR,

--- a/controllers/clienteController.js
+++ b/controllers/clienteController.js
@@ -74,8 +74,7 @@ async function encontrarOuCriarCliente(telefone, profileName = "Cliente") {
     }
     return cliente;
   } catch (error) {
-    console.error('Erro:', error, error && error.stack, JSON.stringify(error));
-    logger.error("Erro ao encontrar ou criar cliente:", error);
+    logger.error(null, error);
     throw error;
   } finally {
     if (client) client.release();
@@ -112,8 +111,7 @@ async function atualizarNomeCliente(clienteId, novoNome) {
     }
     return null;
   } catch (error) {
-    console.error('Erro:', error, error && error.stack, JSON.stringify(error));
-    logger.error("Erro ao atualizar nome do cliente:", error);
+    logger.error(null, error);
     throw error;
   } finally {
     if (client) client.release();

--- a/controllers/dialogflowWebhookController.js
+++ b/controllers/dialogflowWebhookController.js
@@ -319,15 +319,18 @@ async function handleWebhook(req, res) {
 
   if (!msg || !from) return res.status(400).send('Requisição inválida.');
 
+  logger.user(from, msg);
+
   let cliente;
   try {
     cliente = await encontrarOuCriarCliente(from, profileName);
   } catch (e) {
-    logger.error('Erro ao buscar/criar cliente:', e);
+    logger.error(from, e);
     return res.json(createResponse(false, null, mensagens.ERRO_GERAL));
   }
 
   const { intent, parameters, fulfillment } = await detectIntent(from, msg);
+  logger.dialogflow(intent, parameters);
   const estado = agendamentosPendentes.get(from) || {};
   estado.clienteId = cliente.id;
   estado.nome = cliente.nome;
@@ -375,9 +378,10 @@ async function handleWebhook(req, res) {
       default:
         resposta = await handleDefault({ fulfillment });
     }
+    logger.bot(from, resposta);
     res.json(createResponse(true, { reply: resposta }, null));
   } catch (error) {
-    logger.error('Erro no handler:', error);
+    logger.error(from, error);
     res.json(createResponse(false, null, mensagens.ERRO_GERAL));
   }
 }

--- a/controllers/gerenciamentoController.js
+++ b/controllers/gerenciamentoController.js
@@ -34,8 +34,7 @@ async function cancelarAgendamento(agendamentoId, googleEventId) {
     try {
       await cancelarEvento(eventId);
   } catch (e) {
-    console.error('Erro:', e, e && e.stack, JSON.stringify(e));
-    logger.error("Erro ao cancelar evento no Google Calendar:", e);
+    logger.error(null, { message: 'Erro ao cancelar evento no Google Calendar: ' + (e.message || e), stack: e.stack });
   }
 
     await connection.query('UPDATE agendamentos SET status = "cancelado" WHERE id = ?', [agendamentoId]);
@@ -46,8 +45,7 @@ async function cancelarAgendamento(agendamentoId, googleEventId) {
   } catch (error) {
     await connection.rollback();
     await connection.release();
-    console.error('Erro:', error, error && error.stack, JSON.stringify(error));
-    logger.error("Erro em cancelarAgendamento:", error);
+    logger.error(null, { message: 'Erro em cancelarAgendamento: ' + (error.message || error), stack: error.stack });
     return {
       success: false,
       message: "Erro interno ao cancelar o agendamento.",
@@ -71,8 +69,7 @@ async function listarAgendamentosAtivos(clienteId) {
     );
     return rows;
   } catch (error) {
-    console.error('Erro:', error, error && error.stack, JSON.stringify(error));
-    logger.error("Erro ao listar agendamentos ativos:", error);
+    logger.error(null, { message: 'Erro ao listar agendamentos ativos: ' + (error.message || error), stack: error.stack });
     throw new Error("Erro ao listar agendamentos ativos.");
   }
 }
@@ -107,8 +104,7 @@ async function reagendarAgendamento(agendamentoId, novoHorario, googleEventId) {
     try {
       await cancelarEvento(eventId);
   } catch (e) {
-    console.error('Erro:', e, e && e.stack, JSON.stringify(e));
-    logger.error("Erro ao cancelar evento antigo no Google Calendar:", e);
+    logger.error(null, { message: 'Erro ao cancelar evento antigo no Google Calendar: ' + (e.message || e), stack: e.stack });
   }
 
     const evento = await criarAgendamento({ cliente: "", servico: "", horario: novoHorario });
@@ -122,8 +118,7 @@ async function reagendarAgendamento(agendamentoId, novoHorario, googleEventId) {
     return { success: true };
   } catch (error) {
     await pool.query("ROLLBACK");
-    console.error('Erro:', error, error && error.stack, JSON.stringify(error));
-    logger.error("Erro ao reagendar:", error);
+    logger.error(null, { message: 'Erro ao reagendar: ' + (error.message || error), stack: error.stack });
     return {
       success: false,
       message: "Ops, algo deu errado ao reagendar. Tente novamente.",

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ app.post("/webhook", originValidator, handleWebhook);
 
 // Middleware global de tratamento de erros
 app.use((err, req, res, next) => {
-  console.error('[ERROR]', err.stack || err.message || JSON.stringify(err));
+  logger.error(null, err);
   if (err.status === 400 || err.name === 'ValidationError') {
     return res.status(400).json(createResponse(false, null, err.message));
   }

--- a/routes/agendamentoRoutes.js
+++ b/routes/agendamentoRoutes.js
@@ -8,6 +8,7 @@ const {
 const { cancelarAgendamento } = require("../controllers/gerenciamentoController");
 const { ValidationError } = require("../utils/errors");
 const { createResponse } = require("../utils/apiResponse");
+const logger = require("../utils/logger");
 
 // Lista horários disponíveis para uma data (YYYY-MM-DD)
 router.get('/horarios', async (req, res, next) => {
@@ -22,7 +23,7 @@ router.get('/horarios', async (req, res, next) => {
     const horarios = await buscarHorariosDisponiveis(data);
     res.json(createResponse(true, horarios, "Horários disponíveis"));
   } catch (err) {
-    console.error('Erro:', err, err && err.stack, JSON.stringify(err));
+    logger.error(null, err);
     if (err instanceof ValidationError) {
       return res.status(400).json(createResponse(false, null, err.message));
     }
@@ -50,7 +51,7 @@ router.post('/agendar', async (req, res, next) => {
       }, "Agendamento realizado com sucesso")
     );
   } catch (err) {
-    console.error('Erro:', err, err && err.stack, JSON.stringify(err));
+    logger.error(null, err);
     if (err instanceof ValidationError) {
       return res.status(400).json(createResponse(false, null, err.message));
     }
@@ -74,7 +75,7 @@ router.post('/cancelar', async (req, res, next) => {
     }
     res.json(createResponse(true, null, "Agendamento cancelado"));
   } catch (err) {
-    console.error('Erro:', err, err && err.stack, JSON.stringify(err));
+    logger.error(null, err);
     next(err);
   }
 });

--- a/routes/clienteRoutes.js
+++ b/routes/clienteRoutes.js
@@ -7,6 +7,7 @@ const {
 } = require("../controllers/clienteController");
 const { ValidationError } = require("../utils/errors");
 const { createResponse } = require("../utils/apiResponse");
+const logger = require("../utils/logger");
 
 // Cria ou retorna cliente existente a partir do telefone
 router.post('/buscar-ou-criar', async (req, res, next) => {
@@ -22,7 +23,7 @@ router.post('/buscar-ou-criar', async (req, res, next) => {
       createResponse(true, cliente, "Cliente encontrado ou criado com sucesso")
     );
   } catch (err) {
-    console.error('Erro:', err, err && err.stack, JSON.stringify(err));
+    logger.error(null, err);
     if (err instanceof ValidationError) {
       return res.status(400).json(createResponse(false, null, err.message));
     }
@@ -48,7 +49,7 @@ router.put('/:id/nome', async (req, res, next) => {
     }
     res.json(createResponse(true, cliente, "Nome atualizado com sucesso"));
   } catch (err) {
-    console.error('Erro:', err, err && err.stack, JSON.stringify(err));
+    logger.error(null, err);
     if (err instanceof ValidationError) {
       return res.status(400).json(createResponse(false, null, err.message));
     }

--- a/utils/logger.js
+++ b/utils/logger.js
@@ -1,17 +1,50 @@
+const fs = require('fs');
+const path = require('path');
 
-function formatMessage(level, messages) {
+const logsDir = path.join(__dirname, '..', 'logs');
+if (!fs.existsSync(logsDir)) {
+  fs.mkdirSync(logsDir);
+}
+
+function format(level, message) {
   const timestamp = new Date().toISOString();
-  return `[${timestamp}] [${level}] ${messages.join(' ')}`;
+  return `[${timestamp}] [${level}] ${message}`;
 }
 
-function log(level, ...messages) {
-  const formatted = formatMessage(level, messages.map(m => (typeof m === 'string' ? m : JSON.stringify(m))));
-  console.log(formatted);
+function write(line) {
+  fs.appendFileSync(path.join(logsDir, 'servidor.log'), line + '\n');
 }
 
-module.exports = {
-  info: (...messages) => log('INFO', ...messages),
-  warn: (...messages) => log('WARN', ...messages),
-  error: (...messages) => log('ERROR', ...messages),
-};
+function baseLog(level, message) {
+  const line = format(level, message);
+  if (process.env.NODE_ENV !== 'production') {
+    console.log(line);
+  }
+  write(line);
+}
 
+function user(id, msg) {
+  baseLog('USER', `${id}: ${msg}`);
+}
+
+function bot(id, msg) {
+  baseLog('BOT', `Resposta enviada: ${msg}`);
+}
+
+function dialogflow(intent, params) {
+  const paramsStr = JSON.stringify(params);
+  baseLog('DIALOGFLOW', `Intent detectada: ${intent} | Parâmetros: ${paramsStr}`);
+}
+
+function error(userId, err) {
+  const desc = err && err.message ? err.message : String(err);
+  const stack = err && err.stack ? ` | ${err.stack}` : '';
+  const idPart = userId ? `${userId} - ` : '';
+  baseLog('ERROR', `${idPart}${desc}${stack}`);
+}
+
+function info(...msgs) {
+  baseLog('INFO', msgs.join(' '));
+}
+
+module.exports = { user, bot, dialogflow, error, info };


### PR DESCRIPTION
## Summary
- create a logging utility that records user, bot and Dialogflow interactions to `logs/servidor.log`
- log errors and webhook activity using the new logger
- replace console error statements in controllers and routes
- ignore generated log files

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68519be803a88327a851ee3ad4a7cf29