### PR TITLE
Fix calendar day filtering

### DIFF
--- a/services/calendarService.js
+++ b/services/calendarService.js
@@ -58,7 +58,8 @@ async function listarHorariosDisponiveis(data) {
   const filtrados = disponiveis.filter((h) => {
     const dt = new Date(`${ano}-${mes}-${dia}T${h}:00-03:00`);
     const day = dt.getDay();
-    return day > 1 && day <= 6;
+    // 0 = Sunday, so exclude only that day
+    return day !== 0;
   });
 
   return filtrados;


### PR DESCRIPTION
## Summary
- fix filtering for available times in calendar service

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6851ca15d23c83278ef63ca977ae63e4