### PR TITLE
Melhorias no fluxo de agendamento

### DIFF
--- a/__tests__/respostaParser.test.js
+++ b/__tests__/respostaParser.test.js
@@ -22,6 +22,20 @@ describe('parseEscolhaDia', () => {
     expect(res).toEqual({ type: 'verMais' });
   });
 
+  test('reconhece hoje e amanha', () => {
+    const hoje = new Date().toISOString().slice(0, 10);
+    const amanhaDate = new Date();
+    amanhaDate.setDate(amanhaDate.getDate() + 1);
+    const amanha = amanhaDate.toISOString().slice(0, 10);
+    expect(parseEscolhaDia('hoje')).toEqual({ type: 'date', value: hoje });
+    expect(parseEscolhaDia('amanhã')).toEqual({ type: 'date', value: amanha });
+  });
+
+  test('reconhece proxima sexta', () => {
+    const res = parseEscolhaDia('Próxima sexta');
+    expect(res).toEqual({ type: 'weekday', value: 5, next: true });
+  });
+
   test('retorna erro para entrada invalida', () => {
     const res = parseEscolhaDia('xyz');
     expect(res).toEqual({ type: 'invalid', error: DEFAULT_ERROR_MSG });

--- a/controllers/dialogflowWebhookController.js
+++ b/controllers/dialogflowWebhookController.js
@@ -118,7 +118,12 @@ async function handleEscolhaDataHora({ from, msg, parametros }) {
       }
       if (parsed.type === 'weekday') {
         if (parsed.value === 0) return mensagens.DOMINGO_NAO_PERMITIDO;
-        escolhido = diasKeys.find((d) => new Date(d).getDay() === parsed.value);
+        const possiveis = diasKeys.filter(
+          (d) => new Date(d).getDay() === parsed.value,
+        );
+        if (possiveis.length) {
+          escolhido = parsed.next ? possiveis[1] || possiveis[0] : possiveis[0];
+        }
       } else if (parsed.type === 'date') {
         if (new Date(parsed.value).getDay() === 0)
           return mensagens.DOMINGO_NAO_PERMITIDO;
@@ -128,7 +133,22 @@ async function handleEscolhaDataHora({ from, msg, parametros }) {
 
     if (!escolhido || !diasKeys.includes(escolhido)) {
       const listaDias = listarPrimeirosDias(diasDisp, estado.diaIndex);
-      return `Dia inválido. Escolha um destes:\n${listaDias}`;
+      let sugestao = '';
+      try {
+        const proximos = await listarTodosHorariosDisponiveis(14);
+        const proximo = encontrarHorarioProximo(
+          `${escolhido || diasKeys[0]}T00:00:00`,
+          proximos,
+        );
+        if (proximo) {
+          sugestao = ` Próximo horário disponível: ${formatarDataHorarioBr(
+            proximo.dia_horario,
+          )}.`;
+        }
+      } catch (e) {
+        logger.error(from, e);
+      }
+      return `Dia inválido.${sugestao}\nEscolha um destes:\n${listaDias}`;
     }
 
     if (new Date(escolhido).getDay() === 0) {
@@ -160,6 +180,24 @@ async function handleEscolhaDataHora({ from, msg, parametros }) {
     if (!hora) {
       const num = parseInt(msg, 10);
       if (!isNaN(num)) hora = horariosDia[num - 1];
+      const lower = msg.toLowerCase();
+      if (!hora && /primeiro/.test(lower)) {
+        hora = horariosDia[0];
+      }
+      if (!hora && /manh[ãa]/.test(lower)) {
+        hora = horariosDia.find((h) => parseInt(h.split(':')[0]) < 12);
+      }
+      if (!hora && /tarde/.test(lower)) {
+        hora = horariosDia.find((h) => parseInt(h.split(':')[0]) >= 12);
+      }
+      if (!hora) {
+        const m = lower.match(/\b(\d{1,2})(?:h|:(\d{2}))?/);
+        if (m) {
+          const hh = m[1].padStart(2, '0');
+          const mm = m[2] || '00';
+          hora = `${hh}:${mm}`;
+        }
+      }
     }
 
     if (!hora || !horariosDia.includes(hora)) {
@@ -243,7 +281,9 @@ async function handleConfirmarAgendamento({ from }) {
 
 /** Lista agendamentos ativos para cancelamento */
 async function handleCancelamento({ from }) {
-  const agendamentos = await listarAgendamentosAtivos(from);
+  const agendamentos = (await listarAgendamentosAtivos(from)).filter(
+    (a) => new Date(a.horario).getDay() !== 0,
+  );
   if (!agendamentos.length) return mensagens.SEM_AGENDAMENTOS_CANCELAR;
   const lista = agendamentos
     .map((a, i) => `${i + 1}. ${a.servico} em ${formatarDataHorarioBr(a.horario)}`)
@@ -289,7 +329,9 @@ async function handleConfirmarCancelamento({ from, msg }) {
 // Placeholders for reagendamento handlers to keep structure clear
 /** Inicia o fluxo de reagendamento */
 async function handleReagendar({ from }) {
-  const agendamentos = await listarAgendamentosAtivos(from);
+  const agendamentos = (await listarAgendamentosAtivos(from)).filter(
+    (a) => new Date(a.horario).getDay() !== 0,
+  );
   if (!agendamentos.length) return mensagens.SEM_AGENDAMENTOS_REAGENDAR;
   const lista = agendamentos
     .map((a, i) => `${i + 1}. ${a.servico} em ${formatarDataHorarioBr(a.horario)}`)
@@ -385,6 +427,14 @@ async function handleWebhook(req, res) {
   if (!msg || !from) return res.status(400).send('Requisição inválida.');
 
   logger.user(from, msg);
+
+  const texto = (msg || '').trim().toLowerCase();
+  if (/^(cancelar|voltar|reiniciar)/.test(texto)) {
+    agendamentosPendentes.delete(from);
+    const respostaReinicio = await handleWelcome({ from });
+    logger.bot(from, respostaReinicio);
+    return res.json(createResponse(true, { reply: respostaReinicio }, null));
+  }
 
   let cliente;
   try {

--- a/utils/respostaParser.js
+++ b/utils/respostaParser.js
@@ -9,11 +9,42 @@ function parseEscolhaDia(input) {
     return { type: 'invalid', error: DEFAULT_ERROR_MSG };
   }
   const text = input.trim().toLowerCase();
+  const normText = removeAccents(text);
   if (text === 'ver mais dias') {
     return { type: 'verMais' };
   }
 
-  const dataMatch = text.match(/^(\d{1,2})\/(\d{1,2})(?:\/(\d{4}))?$/);
+  if (text === 'hoje') {
+    const hoje = new Date();
+    return { type: 'date', value: hoje.toISOString().slice(0, 10) };
+  }
+
+  if (/^amanh[ãa]$/.test(normText)) {
+    const amanha = new Date();
+    amanha.setDate(amanha.getDate() + 1);
+    return { type: 'date', value: amanha.toISOString().slice(0, 10) };
+  }
+
+  const proxMatch = normText.match(/^proxim[oa]?\s+(\w+)/);
+  if (proxMatch) {
+    const palavra = proxMatch[1];
+    const dias = [
+      'domingo',
+      'segunda',
+      'terça',
+      'quarta',
+      'quinta',
+      'sexta',
+      'sábado',
+    ];
+    for (let i = 0; i < dias.length; i++) {
+      if (removeAccents(dias[i]).startsWith(removeAccents(palavra))) {
+        return { type: 'weekday', value: i, next: true };
+      }
+    }
+  }
+
+  const dataMatch = normText.match(/^(\d{1,2})\/(\d{1,2})(?:\/(\d{4}))?$/);
   if (dataMatch) {
     let [, d, m, a] = dataMatch;
     const year = a || String(new Date().getFullYear());
@@ -23,7 +54,7 @@ function parseEscolhaDia(input) {
   }
 
   const dias = ['domingo', 'segunda', 'terça', 'quarta', 'quinta', 'sexta', 'sábado'];
-  const normalized = removeAccents(text);
+  const normalized = normText;
   for (let i = 0; i < dias.length; i++) {
     if (removeAccents(dias[i]).startsWith(normalized)) {
       return { type: 'weekday', value: i };


### PR DESCRIPTION
## Summary
- expand `parseEscolhaDia` to entender 'hoje', 'amanhã' e 'próxima <semana>'
- sugerir próximo horário quando o dia é inválido
- aceitar expressões naturais de horário ("primeiro", "de manhã", "às 10h")
- permitir reiniciar a conversa com "Cancelar" ou "Voltar"
- ignorar agendamentos de domingo
- testes para novos casos de `parseEscolhaDia`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851cbe137708327a280c25ec3e21566