### PR TITLE
Add scheduling feedback and restrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,3 +145,6 @@ Para que o bot reconheça a escolha de dias e horários de forma natural, inclua
 - "Vou precisar cancelar o agendamento."
 - "Quero alterar meu horário para 17h."
 - "Consegue reagendar para o próximo sábado?"
+
+### Confirmação e Feedback
+Ao final do fluxo o bot sempre envia uma mensagem de resumo com o serviço, data e horário confirmados. A resposta também lembra que você pode reagendar ou cancelar a qualquer momento respondendo **"Reagendar"** ou **"Cancelar"**. Os agendamentos somente são permitidos de segunda a sábado, das 09h às 18h.

--- a/controllers/dialogflowWebhookController.js
+++ b/controllers/dialogflowWebhookController.js
@@ -132,7 +132,10 @@ async function handleEscolhaDataHora({ from, msg, parametros }) {
         return `Mais opções de dias:\n${listaDias}`;
       }
       if (parsed.type === 'weekday') {
-        if (parsed.value === 0) return mensagens.DOMINGO_NAO_PERMITIDO;
+        if (parsed.value === 0) {
+          const listaDias = listarPrimeirosDias(diasDisp, estado.diaIndex);
+          return `${mensagens.DOMINGO_NAO_PERMITIDO}\nEscolha um dia disponível:\n${listaDias}`;
+        }
         const possiveis = diasKeys.filter(
           (d) => new Date(d).getDay() === parsed.value,
         );
@@ -140,8 +143,10 @@ async function handleEscolhaDataHora({ from, msg, parametros }) {
           escolhido = parsed.next ? possiveis[1] || possiveis[0] : possiveis[0];
         }
       } else if (parsed.type === 'date') {
-        if (new Date(parsed.value).getDay() === 0)
-          return mensagens.DOMINGO_NAO_PERMITIDO;
+        if (new Date(parsed.value).getDay() === 0) {
+          const listaDias = listarPrimeirosDias(diasDisp, estado.diaIndex);
+          return `${mensagens.DOMINGO_NAO_PERMITIDO}\nEscolha um dia disponível:\n${listaDias}`;
+        }
         if (diasKeys.includes(parsed.value)) escolhido = parsed.value;
       }
     }
@@ -167,7 +172,8 @@ async function handleEscolhaDataHora({ from, msg, parametros }) {
     }
 
     if (new Date(escolhido).getDay() === 0) {
-      return mensagens.DOMINGO_NAO_PERMITIDO;
+      const listaDias = listarPrimeirosDias(diasDisp, estado.diaIndex);
+      return `${mensagens.DOMINGO_NAO_PERMITIDO}\nEscolha um dia disponível:\n${listaDias}`;
     }
 
     estado.diaEscolhido = escolhido;

--- a/utils/mensagensUsuario.js
+++ b/utils/mensagensUsuario.js
@@ -12,7 +12,7 @@ const MENSAGENS = {
   DOMINGO_NAO_PERMITIDO:
     "Não realizamos agendamentos aos domingos. Trabalhamos apenas de segunda a sábado.",
   HORARIO_INVALIDO:
-    "Horário inválido. Escolha um dos horários disponíveis listados acima.",
+    "Horário inválido ou fora do nosso expediente (09h às 18h). Escolha um dos horários disponíveis listados acima.",
   NAO_AGENDAMENTO_ANDAMENTO:
     "Nenhum agendamento em andamento ou etapa incorreta. Quer agendar um serviço?",
   NAO_ESPERANDO_NOME:

--- a/utils/validation.js
+++ b/utils/validation.js
@@ -78,8 +78,9 @@ function isValidDataHora(dataHora) {
 function isDentroHorarioAtendimento(dataHora) {
   const date = new Date(dataHora);
   if (isNaN(date.getTime())) return false;
+  const dia = date.getDay();
   const h = date.getHours();
-  return h >= 9 && h < 18;
+  return dia !== 0 && h >= 9 && h < 18;
 }
 
 // Valida todos os dados necessários para um agendamento


### PR DESCRIPTION
## Summary
- expand horario validation to exclude Sundays
- clarify horario invalid message
- suggest new dates when user chooses Sunday
- document confirmation message

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851d4b393788327b5fe970f48379649