### PR TITLE
Fix reschedule flow to lookup client by phone

### DIFF
--- a/controllers/clienteController.js
+++ b/controllers/clienteController.js
@@ -81,6 +81,32 @@ async function encontrarOuCriarCliente(telefone, profileName = "Cliente") {
   }
 }
 
+// Busca um cliente existente sem criar um novo registro
+async function buscarClientePorTelefone(telefone) {
+  const telefonePadronizado = padronizarTelefone(telefone);
+  const { error } = schemaTelefone.validate(telefonePadronizado);
+  if (error) {
+    throw new ValidationError(
+      "O número de telefone deve estar no formato +55DDDDDDDDDDD."
+    );
+  }
+  let client;
+  try {
+    client = await pool.getConnection();
+    const [rows] = await client.query(
+      "SELECT id, nome, telefone FROM clientes WHERE telefone = ?",
+      [telefonePadronizado]
+    );
+    if (rows.length === 0) return null;
+    return rows[0];
+  } catch (error) {
+    logger.error(null, error);
+    throw error;
+  } finally {
+    if (client) client.release();
+  }
+}
+
 // Atualiza o nome de um cliente existente.
 async function atualizarNomeCliente(clienteId, novoNome) {
   if (!isValidNome(novoNome)) {
@@ -122,4 +148,5 @@ module.exports = {
   encontrarOuCriarCliente,
   atualizarNomeCliente,
   padronizarTelefone,
+  buscarClientePorTelefone,
 };

--- a/controllers/dialogflowWebhookController.js
+++ b/controllers/dialogflowWebhookController.js
@@ -13,6 +13,7 @@ const { normalizarServico } = require('../utils/stringHelpers');
 const {
   encontrarOuCriarCliente,
   atualizarNomeCliente,
+  buscarClientePorTelefone,
 } = require('./clienteController');
 const {
   agendarServico,
@@ -300,7 +301,10 @@ async function handleConfirmarAgendamento({ from }) {
 
 /** Lista agendamentos ativos para cancelamento */
 async function handleCancelamento({ from }) {
-  const agendamentos = (await listarAgendamentosAtivos(from)).filter(
+  const cliente = await buscarClientePorTelefone(from);
+  if (!cliente) return mensagens.CLIENTE_NAO_ENCONTRADO;
+
+  const agendamentos = (await listarAgendamentosAtivos(cliente.id)).filter(
     (a) => new Date(a.horario).getDay() !== 0,
   );
   if (!agendamentos.length) return mensagens.SEM_AGENDAMENTOS_CANCELAR;
@@ -310,6 +314,7 @@ async function handleCancelamento({ from }) {
   setEstado(from, {
     confirmationStep: 'awaiting_cancelar',
     agendamentos,
+    clienteId: cliente.id,
   });
   return `Qual agendamento deseja cancelar?\n${lista}`;
 }
@@ -339,7 +344,11 @@ async function handleConfirmarCancelamento({ from, msg }) {
     agendamentosPendentes.delete(from);
     return mensagens.CANCELAMENTO_NAO_CONFIRMADO;
   }
-  const result = await cancelarAgendamento(estado.agendamentoId, estado.eventId);
+  const result = await cancelarAgendamento(
+    estado.agendamentoId,
+    estado.eventId,
+    estado.clienteId
+  );
   agendamentosPendentes.delete(from);
   if (!result.success) return mensagens.ERRO_PROCESSAR_CANCELAMENTO;
   return `✅ Agendamento cancelado com sucesso!`;
@@ -348,7 +357,10 @@ async function handleConfirmarCancelamento({ from, msg }) {
 // Placeholders for reagendamento handlers to keep structure clear
 /** Inicia o fluxo de reagendamento */
 async function handleReagendar({ from }) {
-  const agendamentos = (await listarAgendamentosAtivos(from)).filter(
+  const cliente = await buscarClientePorTelefone(from);
+  if (!cliente) return mensagens.CLIENTE_NAO_ENCONTRADO;
+
+  const agendamentos = (await listarAgendamentosAtivos(cliente.id)).filter(
     (a) => new Date(a.horario).getDay() !== 0,
   );
   if (!agendamentos.length) return mensagens.SEM_AGENDAMENTOS_REAGENDAR;
@@ -358,6 +370,7 @@ async function handleReagendar({ from }) {
   setEstado(from, {
     confirmationStep: 'awaiting_reagendamento',
     agendamentos,
+    clienteId: cliente.id,
   });
   return `Qual deseja reagendar?\n${lista}`;
 }
@@ -410,6 +423,7 @@ async function handleConfirmarReagendamento({ from, msg }) {
     estado.agendamentoId,
     estado.novoHorario,
     estado.eventId,
+    estado.clienteId
   );
   agendamentosPendentes.delete(from);
   if (!result.success) return mensagens.ERRO_REAGENDAR;

--- a/controllers/gerenciamentoController.js
+++ b/controllers/gerenciamentoController.js
@@ -8,18 +8,22 @@ const { isValidDataHora } = require("../utils/validation");
 const { ValidationError } = require("../utils/errors");
 const logger = require("../utils/logger");
 
-async function cancelarAgendamento(agendamentoId, googleEventId) {
+async function cancelarAgendamento(agendamentoId, googleEventId, clienteId = null) {
   const connection = await pool.getConnection();
   try {
     await connection.beginTransaction();
 
     let eventId = googleEventId;
     if (!eventId) {
-      const [agendamento] = await connection.query(
-        'SELECT google_event_id FROM agendamentos WHERE id = ? AND status = "ativo"',
-        [agendamentoId]
-      );
-
+      let query =
+        'SELECT google_event_id FROM agendamentos WHERE id = ? AND status = "ativo"';
+      const params = [agendamentoId];
+      if (clienteId) {
+        query += ' AND cliente_id = ?';
+        params.push(clienteId);
+      }
+      const [agendamento] = await connection.query(query, params);
+      
       if (!agendamento || agendamento.length === 0) {
         await connection.release();
         return {
@@ -37,7 +41,17 @@ async function cancelarAgendamento(agendamentoId, googleEventId) {
     logger.error(null, { message: 'Erro ao cancelar evento no Google Calendar: ' + (e.message || e), stack: e.stack });
   }
 
-    await connection.query('UPDATE agendamentos SET status = "cancelado" WHERE id = ?', [agendamentoId]);
+    if (clienteId) {
+      await connection.query(
+        'UPDATE agendamentos SET status = "cancelado" WHERE id = ? AND cliente_id = ?',
+        [agendamentoId, clienteId]
+      );
+    } else {
+      await connection.query(
+        'UPDATE agendamentos SET status = "cancelado" WHERE id = ?',
+        [agendamentoId]
+      );
+    }
 
     await connection.commit();
     await connection.release();
@@ -74,7 +88,7 @@ async function listarAgendamentosAtivos(clienteId) {
   }
 }
 
-async function reagendarAgendamento(agendamentoId, novoHorario, googleEventId) {
+async function reagendarAgendamento(agendamentoId, novoHorario, googleEventId, clienteId = null) {
   if (!isValidDataHora(novoHorario)) {
     return {
       success: false,
@@ -87,10 +101,14 @@ async function reagendarAgendamento(agendamentoId, novoHorario, googleEventId) {
 
     let eventId = googleEventId;
     if (!eventId) {
-      const [agendamento] = await pool.query(
-        'SELECT google_event_id FROM agendamentos WHERE id = ? AND status = "ativo"',
-        [agendamentoId]
-      );
+      let query =
+        'SELECT google_event_id FROM agendamentos WHERE id = ? AND status = "ativo"';
+      const params = [agendamentoId];
+      if (clienteId) {
+        query += ' AND cliente_id = ?';
+        params.push(clienteId);
+      }
+      const [agendamento] = await pool.query(query, params);
       if (!agendamento.length) {
         await pool.query("ROLLBACK");
         return {
@@ -109,10 +127,17 @@ async function reagendarAgendamento(agendamentoId, novoHorario, googleEventId) {
 
     const evento = await criarAgendamento({ cliente: "", servico: "", horario: novoHorario });
 
-    await pool.query(
-      "UPDATE agendamentos SET google_event_id = ?, horario = ? WHERE id = ?",
-      [evento.id, novoHorario, agendamentoId]
-    );
+    if (clienteId) {
+      await pool.query(
+        "UPDATE agendamentos SET google_event_id = ?, horario = ? WHERE id = ? AND cliente_id = ?",
+        [evento.id, novoHorario, agendamentoId, clienteId]
+      );
+    } else {
+      await pool.query(
+        "UPDATE agendamentos SET google_event_id = ?, horario = ? WHERE id = ?",
+        [evento.id, novoHorario, agendamentoId]
+      );
+    }
 
     await pool.query("COMMIT");
     return { success: true };

--- a/utils/mensagensUsuario.js
+++ b/utils/mensagensUsuario.js
@@ -33,6 +33,8 @@ const MENSAGENS = {
     "Nenhum reagendamento em andamento. Quer reagendar um agendamento?",
   REAGENDAMENTO_CANCELADO:
     "Reagendamento cancelado. Deseja escolher outro horário?",
+  CLIENTE_NAO_ENCONTRADO:
+    "Não encontramos seu cadastro. Por favor realize um agendamento primeiro.",
   SEM_AGENDAMENTOS_CANCELAR:
     "Você não tem agendamentos ativos para cancelar.",
   NENHUM_CANCELAMENTO:


### PR DESCRIPTION
## Summary
- add `buscarClientePorTelefone` to fetch client without creating
- show message when client is not found
- use phone lookup for cancel/reschedule intents
- validate agendamento updates using cliente_id

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852be60b598832790b3646eab7b66dd