### PR TITLE
Fix DB relations for scheduling and rescheduling

### DIFF
--- a/__tests__/agendamentoController.test.js
+++ b/__tests__/agendamentoController.test.js
@@ -19,7 +19,13 @@ describe('agendamentoController', () => {
     pool.query.mockImplementation((sql) => {
       if (sql.startsWith('SHOW COLUMNS')) return Promise.resolve([[]]);
       if (sql.startsWith('ALTER TABLE')) return Promise.resolve();
+      if (sql.startsWith('START TRANSACTION')) return Promise.resolve();
+      if (sql.startsWith('COMMIT')) return Promise.resolve();
+      if (sql.startsWith('ROLLBACK')) return Promise.resolve();
       if (sql.startsWith('INSERT INTO agendamentos')) return Promise.resolve([{ insertId: 7 }]);
+      if (sql.startsWith('SELECT id, nome FROM servicos'))
+        return Promise.resolve([[{ id: 1 }, { id: 2 }]]);
+      if (sql.startsWith('INSERT INTO agendamentos_servicos')) return Promise.resolve();
       return Promise.resolve([]);
     });
 
@@ -38,6 +44,8 @@ describe('agendamentoController', () => {
       servicos: ['corte', 'barba'],
       horario: '2030-01-01T09:00:00-03:00'
     });
+    const insertCalls = pool.query.mock.calls.filter(c => c[0].trim().startsWith('INSERT INTO agendamentos_servicos'));
+    expect(insertCalls.length).toBe(2);
     expect(resp).toEqual({ success: true, agendamentoId: 7, eventId: 'e1' });
   });
 

--- a/__tests__/gerenciamentoController.test.js
+++ b/__tests__/gerenciamentoController.test.js
@@ -18,6 +18,7 @@ jest.mock('../services/calendarService', () => ({
 const calendarService = require('../services/calendarService');
 
 const { cancelarAgendamento } = require('../controllers/gerenciamentoController');
+const { listarAgendamentosAtivos } = require('../controllers/gerenciamentoController');
 
 describe('gerenciamentoController', () => {
   beforeEach(() => {
@@ -34,5 +35,12 @@ describe('gerenciamentoController', () => {
     expect(calendarService.cancelarAgendamento).toHaveBeenCalledWith('g1');
     expect(connection.query).toHaveBeenCalledWith('UPDATE agendamentos SET status = "cancelado" WHERE id = ?', [5]);
     expect(resp).toEqual({ success: true });
+  });
+
+  test('listarAgendamentosAtivos utiliza join com servicos', async () => {
+    pool.query.mockResolvedValue([[]]);
+    await listarAgendamentosAtivos(3);
+    const calledSql = pool.query.mock.calls[0][0];
+    expect(calledSql).toMatch(/JOIN agendamentos_servicos/);
   });
 });

--- a/controllers/agendamentoController.js
+++ b/controllers/agendamentoController.js
@@ -113,6 +113,8 @@ async function agendarServico({
       horario,
     });
 
+    await pool.query('START TRANSACTION');
+
     const [result] = await pool.query(
       `INSERT INTO agendamentos (cliente_id, google_event_id, horario, status, data_agendamento)
        VALUES (?, ?, ?, 'ativo', NOW())`,
@@ -120,13 +122,36 @@ async function agendarServico({
     );
     const agendamentoId = result.insertId;
 
-    // A associação de vários serviços ao agendamento deve ser feita em outra
-    // camada (agendamentos_servicos). Mantemos somente a criação do evento no
-    // Calendar aqui.
+    const placeholders = servicos.map(() => '?').join(',');
+    const [servRows] = await pool.query(
+      `SELECT id, nome FROM servicos WHERE nome IN (${placeholders})`,
+      servicos
+    );
+    if (servRows.length !== servicos.length) {
+      await pool.query('ROLLBACK');
+      return {
+        success: false,
+        message: mensagens.SERVICO_INVALIDO,
+      };
+    }
+
+    for (const { id: servicoId } of servRows) {
+      await pool.query(
+        'INSERT INTO agendamentos_servicos (agendamento_id, servico_id) VALUES (?, ?)',
+        [agendamentoId, servicoId]
+      );
+    }
+
+    await pool.query('COMMIT');
 
     return { success: true, agendamentoId, eventId: evento.id };
   } catch (error) {
     logger.error(null, error);
+    try {
+      await pool.query('ROLLBACK');
+    } catch (e) {
+      logger.error(null, e);
+    }
     return {
       success: false,
       message: mensagens.ERRO_AGENDAR,

--- a/controllers/gerenciamentoController.js
+++ b/controllers/gerenciamentoController.js
@@ -16,19 +16,21 @@ async function cancelarAgendamento(agendamentoId, googleEventId, clienteId = nul
     let eventId = googleEventId;
     if (!eventId) {
       let query =
-        'SELECT google_event_id FROM agendamentos WHERE id = ? AND status = "ativo"';
+        `SELECT a.google_event_id FROM agendamentos a
+         JOIN agendamentos_servicos asv ON a.id = asv.agendamento_id
+         WHERE a.id = ? AND a.status = "ativo"`;
       const params = [agendamentoId];
       if (clienteId) {
-        query += ' AND cliente_id = ?';
+        query += ' AND a.cliente_id = ?';
         params.push(clienteId);
       }
       const [agendamento] = await connection.query(query, params);
-      
+
       if (!agendamento || agendamento.length === 0) {
         await connection.release();
         return {
           success: false,
-          message: "Agendamento não encontrado ou já cancelado.",
+          message: "Agendamento não encontrado ou sem serviço vinculado.",
         };
       }
 
@@ -74,11 +76,13 @@ async function listarAgendamentosAtivos(clienteId) {
   }
   try {
     const [rows] = await pool.query(
-      `SELECT a.id, a.google_event_id, a.horario, s.nome AS servico
+      `SELECT a.id, a.google_event_id, a.horario,
+              GROUP_CONCAT(s.nome ORDER BY s.nome SEPARATOR ', ') AS servico
        FROM agendamentos a
        JOIN agendamentos_servicos asv ON a.id = asv.agendamento_id
        JOIN servicos s ON asv.servico_id = s.id
-       WHERE a.cliente_id = ? AND a.status = 'ativo'`,
+       WHERE a.cliente_id = ? AND a.status = 'ativo'
+       GROUP BY a.id`,
       [clienteId]
     );
     return rows;
@@ -102,10 +106,12 @@ async function reagendarAgendamento(agendamentoId, novoHorario, googleEventId, c
     let eventId = googleEventId;
     if (!eventId) {
       let query =
-        'SELECT google_event_id FROM agendamentos WHERE id = ? AND status = "ativo"';
+        `SELECT a.google_event_id FROM agendamentos a
+         JOIN agendamentos_servicos asv ON a.id = asv.agendamento_id
+         WHERE a.id = ? AND a.status = "ativo"`;
       const params = [agendamentoId];
       if (clienteId) {
-        query += ' AND cliente_id = ?';
+        query += ' AND a.cliente_id = ?';
         params.push(clienteId);
       }
       const [agendamento] = await pool.query(query, params);
@@ -113,7 +119,7 @@ async function reagendarAgendamento(agendamentoId, novoHorario, googleEventId, c
         await pool.query("ROLLBACK");
         return {
           success: false,
-          message: "Agendamento não encontrado ou já cancelado.",
+          message: "Agendamento não encontrado ou sem serviço vinculado.",
         };
       }
       eventId = agendamento[0].google_event_id;


### PR DESCRIPTION
## Summary
- ensure agendamento includes service links
- aggregate services when listing active agendamentos
- validate service linkage when cancelling or rescheduling
- update tests for new queries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852c5d78afc83278d35e0512620172e