### PR TITLE
Improve rescheduling flow

### DIFF
--- a/__tests__/gerenciamentoController.test.js
+++ b/__tests__/gerenciamentoController.test.js
@@ -19,11 +19,13 @@ const calendarService = require('../services/calendarService');
 
 const { cancelarAgendamento } = require('../controllers/gerenciamentoController');
 const { listarAgendamentosAtivos } = require('../controllers/gerenciamentoController');
+const { reagendarAgendamento } = require('../controllers/gerenciamentoController');
 
 describe('gerenciamentoController', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     connection.query.mockReset();
+    pool.query.mockReset();
   });
 
   test('cancelarAgendamento atualiza status e cancela evento', async () => {
@@ -42,5 +44,32 @@ describe('gerenciamentoController', () => {
     await listarAgendamentosAtivos(3);
     const calledSql = pool.query.mock.calls[0][0];
     expect(calledSql).toMatch(/JOIN agendamentos_servicos/);
+  });
+
+  test('reagendarAgendamento cria novo evento e atualiza dados', async () => {
+    pool.query.mockImplementation((sql) => {
+      if (sql.startsWith('START TRANSACTION')) return Promise.resolve();
+      if (sql.startsWith('SELECT a.google_event_id'))
+        return Promise.resolve([[{ google_event_id: 'old', cliente_nome: 'Jose', servicos: 'Corte' }]]);
+      if (sql.startsWith('UPDATE agendamentos SET')) return Promise.resolve();
+      if (sql.startsWith('COMMIT')) return Promise.resolve();
+      return Promise.resolve([]);
+    });
+    calendarService.cancelarAgendamento.mockResolvedValue();
+    calendarService.criarAgendamento.mockResolvedValue({ id: 'new' });
+
+    const resp = await reagendarAgendamento(1, '2030-01-01T10:00:00-03:00');
+
+    expect(calendarService.cancelarAgendamento).toHaveBeenCalledWith('old');
+    expect(calendarService.criarAgendamento).toHaveBeenCalledWith({
+      cliente: 'Jose',
+      servicos: ['Corte'],
+      horario: '2030-01-01T10:00:00-03:00',
+    });
+    expect(pool.query).toHaveBeenCalledWith(
+      'UPDATE agendamentos SET google_event_id = ?, horario = ? WHERE id = ?',
+      ['new', '2030-01-01T10:00:00-03:00', 1],
+    );
+    expect(resp).toEqual({ success: true });
   });
 });

--- a/controllers/dialogflowWebhookController.js
+++ b/controllers/dialogflowWebhookController.js
@@ -382,17 +382,24 @@ async function handleConfirmarInicioReagendamento({ from, msg }) {
     return mensagens.NENHUM_REAGENDAMENTO;
   const idx = parseInt(msg) - 1;
   const ag = estado.agendamentos[idx];
-  if (!ag) return mensagens.NENHUM_REAGENDAMENTO;
+  if (!ag) {
+    const lista = estado.agendamentos
+      .map((a, i) => `${i + 1}. ${a.servico} em ${formatarDataHorarioBr(a.horario)}`)
+      .join('\n');
+    return `Opção inválida. Escolha um dos agendamentos abaixo:\n${lista}`;
+  }
   estado.agendamentoId = ag.id;
   estado.eventId = ag.google_event_id;
   estado.servico = ag.servico;
+  estado.horarioAtual = ag.horario;
   estado.confirmationStep = 'awaiting_reagendamento_data';
   setEstado(from, estado);
   const horarios = await listarTodosHorariosDisponiveis();
   const lista = horarios
     .map((h, i) => `${i + 1}. ${formatarDataHorarioBr(h.dia_horario)}`)
     .join('\n');
-  return `Escolha um novo horário:\n${lista}`;
+  return `Você está reagendando ${ag.servico} em ${formatarDataHorarioBr(ag.horario)}.` +
+    `\nEscolha um novo horário:\n${lista}`;
 }
 
 /** Recebe a nova data e hora para o reagendamento */
@@ -403,11 +410,16 @@ async function handleEscolhaDataHoraReagendamento({ from, msg }) {
   const horarios = await listarTodosHorariosDisponiveis();
   const idx = parseInt(msg) - 1;
   const h = horarios[idx];
-  if (!h) return mensagens.HORARIO_INVALIDO;
+  if (!h) {
+    const lista = horarios
+      .map((hr, i) => `${i + 1}. ${formatarDataHorarioBr(hr.dia_horario)}`)
+      .join('\n');
+    return `Horário inválido. Escolha um dos horários disponíveis:\n${lista}`;
+  }
   estado.novoHorario = h.dia_horario;
   estado.confirmationStep = 'awaiting_reagendamento_confirm';
   setEstado(from, estado);
-  return `Confirma reagendar para ${formatarDataHorarioBr(h.dia_horario)}?`;
+  return `Confirma reagendar ${estado.servico} para ${formatarDataHorarioBr(h.dia_horario)}?`;
 }
 
 /** Finaliza o reagendamento se confirmado */
@@ -427,7 +439,7 @@ async function handleConfirmarReagendamento({ from, msg }) {
   );
   agendamentosPendentes.delete(from);
   if (!result.success) return mensagens.ERRO_REAGENDAR;
-  return `✅ Agendamento reagendado com sucesso!`;
+  return `✅ Horário atualizado! ${estado.servico} agora está marcado para ${formatarDataHorarioBr(estado.novoHorario)}.`;
 }
 
 /** Fallback para intents não mapeadas */

--- a/controllers/gerenciamentoController.js
+++ b/controllers/gerenciamentoController.js
@@ -104,16 +104,23 @@ async function reagendarAgendamento(agendamentoId, novoHorario, googleEventId, c
     await pool.query("START TRANSACTION");
 
     let eventId = googleEventId;
-    if (!eventId) {
+    let clienteNome;
+    let servicos = [];
+    {
       let query =
-        `SELECT a.google_event_id FROM agendamentos a
+        `SELECT a.google_event_id, c.nome AS cliente_nome,
+                GROUP_CONCAT(s.nome ORDER BY s.nome SEPARATOR ', ') AS servicos
+         FROM agendamentos a
+         JOIN clientes c ON a.cliente_id = c.id
          JOIN agendamentos_servicos asv ON a.id = asv.agendamento_id
+         JOIN servicos s ON asv.servico_id = s.id
          WHERE a.id = ? AND a.status = "ativo"`;
       const params = [agendamentoId];
       if (clienteId) {
         query += ' AND a.cliente_id = ?';
         params.push(clienteId);
       }
+      query += ' GROUP BY a.id';
       const [agendamento] = await pool.query(query, params);
       if (!agendamento.length) {
         await pool.query("ROLLBACK");
@@ -122,7 +129,9 @@ async function reagendarAgendamento(agendamentoId, novoHorario, googleEventId, c
           message: "Agendamento não encontrado ou sem serviço vinculado.",
         };
       }
-      eventId = agendamento[0].google_event_id;
+      eventId = eventId || agendamento[0].google_event_id;
+      clienteNome = agendamento[0].cliente_nome;
+      servicos = (agendamento[0].servicos || '').split(/,\s*/).filter(Boolean);
     }
 
     try {
@@ -131,7 +140,11 @@ async function reagendarAgendamento(agendamentoId, novoHorario, googleEventId, c
     logger.error(null, { message: 'Erro ao cancelar evento antigo no Google Calendar: ' + (e.message || e), stack: e.stack });
   }
 
-    const evento = await criarAgendamento({ cliente: "", servico: "", horario: novoHorario });
+    const evento = await criarAgendamento({
+      cliente: clienteNome || "",
+      servicos,
+      horario: novoHorario,
+    });
 
     if (clienteId) {
       await pool.query(


### PR DESCRIPTION
## Summary
- enhance flow to track selected appointment and show current info
- validate option numbers when rescheduling
- keep client and service when updating schedule
- add unit test for `reagendarAgendamento`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6852cd89978c83279276d36ac3b25576