### PR TITLE
Fix date labels for scheduling days

### DIFF
--- a/utils/dataHelpers.js
+++ b/utils/dataHelpers.js
@@ -1,5 +1,5 @@
 const { listarHorariosDisponiveis } = require('../services/calendarService');
-const { DateTime } = require('./luxonShim');
+const { DateTime } = require('luxon');
 
 const TIME_ZONE = 'America/Sao_Paulo';
 


### PR DESCRIPTION
## Summary
- switch helper to use Luxon for date formatting
- ensure weekday labels show correctly in Portuguese

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6852dc91320c8327a56766cb95528705