### PR TITLE
Handle reschedule selection

### DIFF
--- a/controllers/dialogflowWebhookController.js
+++ b/controllers/dialogflowWebhookController.js
@@ -380,8 +380,12 @@ async function handleConfirmarInicioReagendamento({ from, msg }) {
   const estado = agendamentosPendentes.get(from);
   if (!estado || estado.confirmationStep !== 'awaiting_reagendamento')
     return mensagens.NENHUM_REAGENDAMENTO;
-  const idx = parseInt(msg) - 1;
-  const ag = estado.agendamentos[idx];
+  const escolha = parseInt(msg, 10);
+  const idx = escolha - 1;
+  const ag =
+    !isNaN(escolha) && escolha > 0 && escolha <= estado.agendamentos.length
+      ? estado.agendamentos[idx]
+      : null;
   if (!ag) {
     const lista = estado.agendamentos
       .map((a, i) => `${i + 1}. ${a.servico} em ${formatarDataHorarioBr(a.horario)}`)
@@ -408,8 +412,12 @@ async function handleEscolhaDataHoraReagendamento({ from, msg }) {
   if (!estado || estado.confirmationStep !== 'awaiting_reagendamento_data')
     return mensagens.NENHUM_REAGENDAMENTO;
   const horarios = await listarTodosHorariosDisponiveis();
-  const idx = parseInt(msg) - 1;
-  const h = horarios[idx];
+  const escolha = parseInt(msg, 10);
+  const idx = escolha - 1;
+  const h =
+    !isNaN(escolha) && escolha > 0 && escolha <= horarios.length
+      ? horarios[idx]
+      : null;
   if (!h) {
     const lista = horarios
       .map((hr, i) => `${i + 1}. ${formatarDataHorarioBr(hr.dia_horario)}`)

--- a/dialogflow/intents/confirmar_inicio_reagendamento.json
+++ b/dialogflow/intents/confirmar_inicio_reagendamento.json
@@ -1,0 +1,27 @@
+{
+  "displayName": "confirmar_inicio_reagendamento",
+  "priority": 500000,
+  "trainingPhrases": [
+    { "type": "EXAMPLE", "parts": [ { "text": "1", "entityType": "@sys.number", "alias": "escolha" } ] },
+    { "type": "EXAMPLE", "parts": [ { "text": "2", "entityType": "@sys.number", "alias": "escolha" } ] },
+    { "type": "EXAMPLE", "parts": [ { "text": "3", "entityType": "@sys.number", "alias": "escolha" } ] },
+    { "type": "EXAMPLE", "parts": [ { "text": "Quero a opção 4", "entityType": "@sys.number", "alias": "escolha" } ] }
+  ],
+  "parameters": [
+    {
+      "id": "escolha",
+      "entityType": "@sys.number",
+      "alias": "escolha",
+      "isList": false
+    }
+  ],
+  "inputContextNames": [
+    "aguardando_selecao_reagendamento"
+  ],
+  "outputContexts": [
+    {
+      "name": "aguardando_novo_horario",
+      "lifespanCount": 5
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- improve index validation when selecting schedule to reschedule
- add Dialogflow intent example for number selection in reschedule flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852e6743f248327bd68a366af12500e