### PR TITLE
Add helper to compute next weekday date

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,3 +148,31 @@ Para que o bot reconheça a escolha de dias e horários de forma natural, inclua
 
 ### Confirmação e Feedback
 Ao final do fluxo o bot sempre envia uma mensagem de resumo com o serviço, data e horário confirmados. A resposta também lembra que você pode reagendar ou cancelar a qualquer momento respondendo **"Reagendar"** ou **"Cancelar"**. Os agendamentos somente são permitidos de segunda a sábado, das 09h às 18h.
+
+## Utilizando dias da semana
+
+Para converter um texto como "quinta" ou "amanhã" na data correta respeitando o fuso horário, use a função `getNextDateFromText`:
+
+```js
+const { getNextDateFromText } = require('./utils/dataHelpers');
+const { listarHorariosDisponiveis } = require('./services/calendarService');
+
+(async () => {
+  const data = getNextDateFromText('quinta');
+  if (data) {
+    const horarios = await listarHorariosDisponiveis(data);
+    console.log(data, horarios);
+  }
+})();
+```
+
+### Debug de timezone
+
+Verifique se o Node está utilizando o fuso correto:
+
+```js
+console.log('Sistema:', new Date().toString());
+console.log('S\u00e3o Paulo:', new Intl.DateTimeFormat('pt-BR', { timeZone: 'America/Sao_Paulo' }).format(new Date()));
+```
+
+Se houver diverg\u00eancia, defina `TZ=America/Sao_Paulo` ao iniciar a aplica\u00e7\u00e3o.

--- a/__tests__/dataHelpers.test.js
+++ b/__tests__/dataHelpers.test.js
@@ -1,0 +1,22 @@
+const { getNextDateFromText } = require('../utils/dataHelpers');
+
+describe('getNextDateFromText', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-06-05T10:00:00-03:00'));
+  });
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  test('converte dia da semana para a proxima data', () => {
+    expect(getNextDateFromText('quinta')).toBe('2024-06-06');
+    expect(getNextDateFromText('sabado')).toBe('2024-06-08');
+  });
+
+  test('entende acentos e hoje/amanha', () => {
+    expect(getNextDateFromText('sábado')).toBe('2024-06-08');
+    expect(getNextDateFromText('hoje')).toBe('2024-06-05');
+    expect(getNextDateFromText('amanhã')).toBe('2024-06-06');
+  });
+});

--- a/utils/dataHelpers.js
+++ b/utils/dataHelpers.js
@@ -3,6 +3,47 @@ const { DateTime } = require('luxon');
 
 const TIME_ZONE = 'America/Sao_Paulo';
 
+function removeAccents(str) {
+  return str.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+}
+
+/**
+ * Converte o texto de um dia da semana ("quinta", "sabado", "hoje", etc)
+ * para a data (YYYY-MM-DD) da próxima ocorrência a partir de hoje.
+ * O cálculo considera sempre o fuso "America/Sao_Paulo".
+ * @param {string} texto
+ * @returns {string|null} Data no formato ISO ou null se inválido
+ */
+function getNextDateFromText(texto) {
+  if (!texto || typeof texto !== 'string') return null;
+  const norm = removeAccents(texto.trim().toLowerCase());
+
+  const hoje = DateTime.now().setZone(TIME_ZONE).startOf('day');
+
+  if (norm === 'hoje') return hoje.toISODate();
+  if (norm === 'amanha') return hoje.plus({ days: 1 }).toISODate();
+
+  const dias = [
+    'domingo',
+    'segunda',
+    'terca',
+    'quarta',
+    'quinta',
+    'sexta',
+    'sabado',
+  ];
+
+  let idx = dias.indexOf(norm);
+  if (idx === -1) {
+    idx = dias.findIndex((d) => d.startsWith(norm));
+  }
+  if (idx === -1) return null;
+
+  const hojeIdx = hoje.weekday % 7; // domingo -> 0
+  const delta = (idx - hojeIdx + 7) % 7;
+  return hoje.plus({ days: delta }).toISODate();
+}
+
 function formatarDataHorarioBr(date) {
   const dt =
     typeof date === 'string'
@@ -127,4 +168,5 @@ module.exports = {
   formatarDiaBr,
   gerarMensagemDias,
   gerarMensagemHorarios,
+  getNextDateFromText,
 };


### PR DESCRIPTION
## Summary
- add `getNextDateFromText` in `dataHelpers`
- document weekday conversion and timezone debug tips
- test the new helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852eb2f7ca48327bb1abbd3c0dcbc4d