### PR TITLE
Add session context for cancel and reschedule flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,13 @@ Para que o bot reconheça a escolha de dias e horários de forma natural, inclua
 - "Quero alterar meu horário para 17h."
 - "Consegue reagendar para o próximo sábado?"
 
+### Fluxos de Cancelamento e Reagendamento
+O backend mantém o contexto do fluxo em memória e somente processa intents compatíveis.
+Quando o usuário envia **"Cancelar"**, o bot exibe os agendamentos ativos e, após a escolha,
+pede confirmação do cancelamento. Para **"Reagendar"**, a lógica é similar: primeiro lista os agendamentos e,
+após a seleção, solicita a nova data e horário. Intents de outros fluxos são ignoradas enquanto o contexto estiver ativo,
+evitando quedas para respostas de "não entendi".
+
 ### Confirmação e Feedback
 Ao final do fluxo o bot sempre envia uma mensagem de resumo com o serviço, data e horário confirmados. A resposta também lembra que você pode reagendar ou cancelar a qualquer momento respondendo **"Reagendar"** ou **"Cancelar"**. Os agendamentos somente são permitidos de segunda a sábado, das 09h às 18h.
 

--- a/controllers/dialogflowWebhookController.js
+++ b/controllers/dialogflowWebhookController.js
@@ -40,6 +40,20 @@ const projectId = process.env.DIALOGFLOW_PROJECT_ID;
 
 const agendamentosPendentes = new Map();
 
+const FLUXO_INTENTS = {
+  reagendamento: new Set([
+    'reagendar_agendamento',
+    'confirmar_inicio_reagendamento',
+    'escolha_datahora_reagendamento',
+    'confirmar_reagendamento',
+  ]),
+  cancelamento: new Set([
+    'cancelar_agendamento',
+    'selecionar_cancelamento',
+    'confirmar_cancelamento',
+  ]),
+};
+
 function getEstado(from) {
   return agendamentosPendentes.get(from) || {};
 }
@@ -49,6 +63,12 @@ function setEstado(from, updates) {
   const novo = { ...atual, ...updates };
   agendamentosPendentes.set(from, novo);
   return novo;
+}
+
+function intentNoFluxo(intent, fluxo) {
+  if (!fluxo) return true;
+  const intents = FLUXO_INTENTS[fluxo];
+  return intents ? intents.has(intent) : true;
 }
 
 const SERVICOS_VALIDOS = {
@@ -316,6 +336,7 @@ async function handleCancelamento({ from }) {
     .map((a, i) => `${i + 1}. ${a.servico} em ${formatarDataHorarioBr(a.horario)}`)
     .join('\n');
   setEstado(from, {
+    fluxo: 'cancelamento',
     confirmationStep: 'awaiting_cancelar',
     agendamentos,
     clienteId: cliente.id,
@@ -372,6 +393,7 @@ async function handleReagendar({ from }) {
     .map((a, i) => `${i + 1}. ${a.servico} em ${formatarDataHorarioBr(a.horario)}`)
     .join('\n');
   setEstado(from, {
+    fluxo: 'reagendamento',
     confirmationStep: 'awaiting_reagendamento',
     agendamentos,
     clienteId: cliente.id,
@@ -402,10 +424,10 @@ async function handleConfirmarInicioReagendamento({ from, msg }) {
   estado.servico = ag.servico;
   estado.horarioAtual = ag.horario;
   estado.confirmationStep = 'awaiting_reagendamento_data';
+  estado.horariosDisponiveis = await listarTodosHorariosDisponiveis();
   setEstado(from, estado);
   logger.info(from, `Reagendamento selecionado id=${ag.id} servico=${ag.servico}`);
-  const horarios = await listarTodosHorariosDisponiveis();
-  const lista = horarios
+  const lista = estado.horariosDisponiveis
     .map((h, i) => `${i + 1}. ${formatarDataHorarioBr(h.dia_horario)}`)
     .join('\n');
   return `Você está reagendando ${ag.servico} em ${formatarDataHorarioBr(ag.horario)}.` +
@@ -417,7 +439,7 @@ async function handleEscolhaDataHoraReagendamento({ from, msg, parametros }) {
   const estado = agendamentosPendentes.get(from);
   if (!estado || estado.confirmationStep !== 'awaiting_reagendamento_data')
     return mensagens.NENHUM_REAGENDAMENTO;
-  const horarios = await listarTodosHorariosDisponiveis();
+  const horarios = estado.horariosDisponiveis || (await listarTodosHorariosDisponiveis());
   logger.info(from, `handleEscolhaDataHoraReagendamento - servico=${estado.servico}`);
   let escolha = parseInt(msg, 10);
   if (isNaN(escolha) && parametros && parametros['number']) {
@@ -484,7 +506,39 @@ async function handleDefault({ from, fulfillment }) {
         );
         return `Confirma o agendamento de *${estado.servico}* em *${resumo}* para *${estado.nome}*?`;
       }
+      case 'awaiting_cancelar': {
+        const lista = (estado.agendamentos || [])
+          .map((a, i) => `${i + 1}. ${a.servico} em ${formatarDataHorarioBr(a.horario)}`)
+          .join('\n');
+        return `Escolha o agendamento que deseja cancelar:\n${lista}`;
+      }
+      case 'awaiting_cancel_confirm': {
+        const ag = (estado.agendamentos || []).find(a => a.id === estado.agendamentoId);
+        const horario = ag ? formatarDataHorarioBr(ag.horario) : '';
+        return `Confirma o cancelamento de ${estado.servico} em ${horario}?`;
+      }
+      case 'awaiting_reagendamento': {
+        const lista = (estado.agendamentos || [])
+          .map((a, i) => `${i + 1}. ${a.servico} em ${formatarDataHorarioBr(a.horario)}`)
+          .join('\n');
+        return `Qual deseja reagendar?\n${lista}`;
+      }
+      case 'awaiting_reagendamento_data': {
+        const horarios = (estado.horariosDisponiveis || [])
+          .map((h, i) => `${i + 1}. ${formatarDataHorarioBr(h.dia_horario)}`)
+          .join('\n');
+        return `Escolha um novo horário:\n${horarios}`;
+      }
+      case 'awaiting_reagendamento_confirm': {
+        return `Confirma reagendar ${estado.servico} para ${formatarDataHorarioBr(estado.novoHorario)}?`;
+      }
       default:
+        if (estado.fluxo === 'reagendamento') {
+          return mensagens.FLUXO_REAGENDAMENTO_EM_ANDAMENTO;
+        }
+        if (estado.fluxo === 'cancelamento') {
+          return mensagens.FLUXO_CANCELAMENTO_EM_ANDAMENTO;
+        }
         break;
     }
   }
@@ -540,6 +594,12 @@ async function handleWebhook(req, res) {
     nome: cliente.nome,
     telefone: cliente.telefone,
   });
+
+  if (!intentNoFluxo(intent, estado.fluxo)) {
+    const respostaFluxo = await handleDefault({ from, fulfillment: '' });
+    logger.bot(from, respostaFluxo);
+    return res.json(createResponse(true, { reply: respostaFluxo }, null));
+  }
 
   let resposta;
   try {

--- a/dialogflow/intents/cancelar_agendamento.json
+++ b/dialogflow/intents/cancelar_agendamento.json
@@ -1,0 +1,13 @@
+{
+  "displayName": "cancelar_agendamento",
+  "priority": 500000,
+  "trainingPhrases": [
+    { "type": "EXAMPLE", "parts": [ { "text": "Quero cancelar" } ] },
+    { "type": "EXAMPLE", "parts": [ { "text": "Preciso cancelar meu horário" } ] },
+    { "type": "EXAMPLE", "parts": [ { "text": "Desmarcar agendamento" } ] }
+  ],
+  "inputContextNames": [],
+  "outputContexts": [
+    { "name": "aguardando_cancelamento", "lifespanCount": 5 }
+  ]
+}

--- a/dialogflow/intents/confirmar_inicio_reagendamento.json
+++ b/dialogflow/intents/confirmar_inicio_reagendamento.json
@@ -16,11 +16,11 @@
     }
   ],
   "inputContextNames": [
-    "aguardando_selecao_reagendamento"
+    "aguardando_reagendamento"
   ],
   "outputContexts": [
     {
-      "name": "aguardando_novo_horario",
+      "name": "aguardando_reagendamento",
       "lifespanCount": 5
     }
   ]

--- a/dialogflow/intents/reagendar_agendamento.json
+++ b/dialogflow/intents/reagendar_agendamento.json
@@ -1,0 +1,13 @@
+{
+  "displayName": "reagendar_agendamento",
+  "priority": 500000,
+  "trainingPhrases": [
+    { "type": "EXAMPLE", "parts": [ { "text": "Quero reagendar" } ] },
+    { "type": "EXAMPLE", "parts": [ { "text": "Preciso remarcar meu horário" } ] },
+    { "type": "EXAMPLE", "parts": [ { "text": "Mudar horário" } ] }
+  ],
+  "inputContextNames": [],
+  "outputContexts": [
+    { "name": "aguardando_reagendamento", "lifespanCount": 5 }
+  ]
+}

--- a/utils/mensagensUsuario.js
+++ b/utils/mensagensUsuario.js
@@ -33,12 +33,16 @@ const MENSAGENS = {
     "Nenhum reagendamento em andamento. Quer reagendar um agendamento?",
   REAGENDAMENTO_CANCELADO:
     "Reagendamento cancelado. Deseja escolher outro horário?",
+  FLUXO_REAGENDAMENTO_EM_ANDAMENTO:
+    "Estamos no fluxo de reagendamento. Escolha uma das opções apresentadas ou envie 'Cancelar' para sair.",
   CLIENTE_NAO_ENCONTRADO:
     "Não encontramos seu cadastro. Por favor realize um agendamento primeiro.",
   SEM_AGENDAMENTOS_CANCELAR:
     "Você não tem agendamentos ativos para cancelar.",
   NENHUM_CANCELAMENTO:
     "Nenhum cancelamento em andamento. Quer cancelar um agendamento?",
+  FLUXO_CANCELAMENTO_EM_ANDAMENTO:
+    "Estamos no fluxo de cancelamento. Escolha uma das opções apresentadas ou envie 'Cancelar' para sair.",
   CANCELAMENTO_NAO_CONFIRMADO:
     "Cancelamento não confirmado. Deseja fazer algo mais?",
   AGENDAMENTO_NAO_CONFIRMADO:


### PR DESCRIPTION
## Summary
- improve user state handling to track current flow
- use new dialogflow intents with contexts for cancelling and rescheduling
- prevent mixing flows in `handleWebhook`
- document how flows work

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68530cb95df08327b280c9f254793809