### PR TITLE
Fix duplicate import in dialogflow webhook controller

### DIFF
--- a/controllers/dialogflowWebhookController.js
+++ b/controllers/dialogflowWebhookController.js
@@ -32,9 +32,6 @@ const {
   isValidServico,
   isValidDataHora,
 } = require('../utils/validation');
-const {
-  listarDiasDisponiveis,
-} = require('../utils/dataHelpers');
 
 const sessionClient = new dialogflow.SessionsClient({
   keyFilename: process.env.DIALOGFLOW_KEYFILE,


### PR DESCRIPTION
## Summary
- remove repeated `listarDiasDisponiveis` import to avoid identifier conflicts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685318ef21648327b93dc9d200bbc4e7