### PR TITLE
Fix context names for reschedule intents

### DIFF
--- a/dialogflow/intents/confirmar_inicio_reagendamento.json
+++ b/dialogflow/intents/confirmar_inicio_reagendamento.json
@@ -5,7 +5,9 @@
     { "type": "EXAMPLE", "parts": [ { "text": "1", "entityType": "@sys.number", "alias": "escolha" } ] },
     { "type": "EXAMPLE", "parts": [ { "text": "2", "entityType": "@sys.number", "alias": "escolha" } ] },
     { "type": "EXAMPLE", "parts": [ { "text": "3", "entityType": "@sys.number", "alias": "escolha" } ] },
-    { "type": "EXAMPLE", "parts": [ { "text": "Quero a opção 4", "entityType": "@sys.number", "alias": "escolha" } ] }
+    { "type": "EXAMPLE", "parts": [ { "text": "Quero a opção 4", "entityType": "@sys.number", "alias": "escolha" } ] },
+    { "type": "EXAMPLE", "parts": [ { "text": "sexta 10h" } ] },
+    { "type": "EXAMPLE", "parts": [ { "text": "amanhã 14:00" } ] }
   ],
   "parameters": [
     {
@@ -16,11 +18,11 @@
     }
   ],
   "inputContextNames": [
-    "aguardando_reagendamento"
+    "reagendamento_awaiting_datahora"
   ],
   "outputContexts": [
     {
-      "name": "aguardando_reagendamento",
+      "name": "reagendamento_datahora_selected",
       "lifespanCount": 5
     }
   ]

--- a/dialogflow/intents/reagendar_agendamento.json
+++ b/dialogflow/intents/reagendar_agendamento.json
@@ -8,6 +8,6 @@
   ],
   "inputContextNames": [],
   "outputContexts": [
-    { "name": "aguardando_reagendamento", "lifespanCount": 5 }
+    { "name": "reagendamento_awaiting_datahora", "lifespanCount": 5 }
   ]
 }


### PR DESCRIPTION
## Summary
- rename the context returned by `reagendar_agendamento`
- adjust `confirmar_inicio_reagendamento` to use new context names and add examples

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685324f50dcc8327ae38f5c453408aa9