### PR TITLE
Fix reschedule option recognition

### DIFF
--- a/controllers/dialogflowWebhookController.js
+++ b/controllers/dialogflowWebhookController.js
@@ -615,8 +615,8 @@ const intentHandlers = {
   selecionar_cancelamento: handleSelecionarCancelamento,
   confirmar_cancelamento: handleConfirmarCancelamento,
   reagendar_agendamento: handleReagendar,
-  escolha_datahora_reagendamento: handleConfirmarInicioReagendamento,
-  confirmar_inicio_reagendamento: handleEscolhaDataHoraReagendamento,
+  confirmar_inicio_reagendamento: handleConfirmarInicioReagendamento,
+  escolha_datahora_reagendamento: handleEscolhaDataHoraReagendamento,
   confirmar_reagendamento: handleConfirmarReagendamento,
 };
 

--- a/dialogflow/intents/escolha_datahora_reagendamento.json
+++ b/dialogflow/intents/escolha_datahora_reagendamento.json
@@ -1,0 +1,30 @@
+{
+  "displayName": "escolha_datahora_reagendamento",
+  "priority": 500000,
+  "trainingPhrases": [
+    { "type": "EXAMPLE", "parts": [ { "text": "amanhã 15h" } ] },
+    { "type": "EXAMPLE", "parts": [ { "text": "sexta 10:00" } ] },
+    { "type": "EXAMPLE", "parts": [ { "text": "1", "entityType": "@sys.number", "alias": "opcao" } ] },
+    { "type": "EXAMPLE", "parts": [ { "text": "2", "entityType": "@sys.number", "alias": "opcao" } ] }
+  ],
+  "parameters": [
+    {
+      "id": "date-time",
+      "entityType": "@sys.date-time",
+      "alias": "date-time",
+      "isList": false
+    },
+    {
+      "id": "time",
+      "entityType": "@sys.time",
+      "alias": "time",
+      "isList": false
+    }
+  ],
+  "inputContextNames": [
+    "reagendamento_datahora_selected"
+  ],
+  "outputContexts": [
+    { "name": "reagendamento_datahora_selected", "lifespanCount": 5 }
+  ]
+}


### PR DESCRIPTION
## Summary
- fix handler mapping for reschedule intents
- add missing `escolha_datahora_reagendamento` intent definition

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d6b43193c8327aeae097d5a187383