### PR TITLE
Handle ordinal text in appointment parser

### DIFF
--- a/__tests__/respostaParser.test.js
+++ b/__tests__/respostaParser.test.js
@@ -58,6 +58,11 @@ describe('parseEscolhaAgendamento', () => {
     expect(res).toEqual(ags[0]);
   });
 
+  test('seleciona por ordinal', () => {
+    const res = parseEscolhaAgendamento('segunda opção', ags);
+    expect(res).toEqual(ags[1]);
+  });
+
   test('seleciona por descricao', () => {
     const texto = `Barba ${formatarDataHorarioBr(ags[1].horario)}`;
     const res = parseEscolhaAgendamento(texto, ags);

--- a/utils/respostaParser.js
+++ b/utils/respostaParser.js
@@ -69,7 +69,37 @@ const { formatarDataHorarioBr } = require('./dataHelpers');
 function parseEscolhaAgendamento(input, agendamentos) {
   if (!input || !Array.isArray(agendamentos)) return null;
   const texto = removeAccents(String(input).trim().toLowerCase());
-  const numero = parseInt(texto, 10);
+
+  let numero = parseInt(texto, 10);
+
+  if (isNaN(numero)) {
+    const ordinals = {
+      primeira: 1,
+      primeiro: 1,
+      segunda: 2,
+      segundo: 2,
+      terceira: 3,
+      terceiro: 3,
+      quarta: 4,
+      quarto: 4,
+      quinta: 5,
+      quinto: 5,
+      sexta: 6,
+      sexto: 6,
+      setima: 7,
+      setimo: 7,
+      oitava: 8,
+      oitavo: 8,
+      nona: 9,
+      nono: 9,
+      decima: 10,
+      decimo: 10,
+    };
+
+    const match = Object.keys(ordinals).find((w) => texto.includes(w));
+    if (match) numero = ordinals[match];
+  }
+
   if (!isNaN(numero)) return agendamentos[numero - 1] || null;
 
   return (


### PR DESCRIPTION
## Summary
- extend `parseEscolhaAgendamento` to understand ordinal words
- test selecting an appointment by ordinal phrase

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d7376992483279530d2ba5c355a4f