### PR TITLE
Fix Dialogflow context for reschedule confirmation

### DIFF
--- a/controllers/dialogflowWebhookController.js
+++ b/controllers/dialogflowWebhookController.js
@@ -529,6 +529,8 @@ async function handleEscolhaDataHoraReagendamento({ from, msg, parametros }) {
 
     estado.novoHorario = `${estado.novoDia}T${hora}:00`;
     estado.confirmationStep = 'awaiting_reagendamento_confirm';
+    // Mantém contexto específico até a confirmação do reagendamento
+    estado.contextoDialogflow = 'aguardando_confirmacao_reagendamento';
     setEstado(from, estado);
     return `Confirma reagendar ${estado.servico} para ${formatarDataHorarioBr(estado.novoHorario)}?`;
   }

--- a/dialogflow/intents/confirmar_inicio_reagendamento.json
+++ b/dialogflow/intents/confirmar_inicio_reagendamento.json
@@ -24,6 +24,10 @@
     {
       "name": "reagendamento_datahora_selected",
       "lifespanCount": 5
+    },
+    {
+      "name": "reagendamento_awaiting_datahora",
+      "lifespanCount": 0
     }
   ]
 }

--- a/dialogflow/intents/confirmar_reagendamento.json
+++ b/dialogflow/intents/confirmar_reagendamento.json
@@ -3,12 +3,13 @@
   "priority": 500000,
   "trainingPhrases": [
     { "type": "EXAMPLE", "parts": [ { "text": "sim" } ] },
-    { "type": "EXAMPLE", "parts": [ { "text": "confirmar" } ] },
+    { "type": "EXAMPLE", "parts": [ { "text": "ok" } ] },
     { "type": "EXAMPLE", "parts": [ { "text": "pode ser" } ] },
+    { "type": "EXAMPLE", "parts": [ { "text": "confirmar" } ] },
     { "type": "EXAMPLE", "parts": [ { "text": "confirmado" } ] }
   ],
   "inputContextNames": [
-    "reagendamento_datahora_selected"
+    "aguardando_confirmacao_reagendamento"
   ],
   "outputContexts": []
 }


### PR DESCRIPTION
## Summary
- set new confirmation context when asking to confirm rescheduling
- ensure Dialogflow intent `confirmar_reagendamento` only triggers when `aguardando_confirmacao_reagendamento` context is present and add training phrase "ok"
- clean previous context after selecting an appointment for rescheduling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685da81544d48327967465d3c76219d4