### PR TITLE
Fix repeated reschedule confirmation

### DIFF
--- a/controllers/dialogflowWebhookController.js
+++ b/controllers/dialogflowWebhookController.js
@@ -757,6 +757,13 @@ async function handleWebhook(req, res) {
     intent = 'escolha_datahora_reagendamento';
   }
 
+  if (
+    estado.confirmationStep === 'awaiting_reagendamento_confirm' &&
+    intent === 'default'
+  ) {
+    intent = 'confirmar_reagendamento';
+  }
+
   if (!intentNoFluxo(intent, estado.fluxo)) {
     const respostaFluxo = await handleDefault({ from, fulfillment: '' });
     logger.bot(from, respostaFluxo);


### PR DESCRIPTION
## Summary
- map default intent to `confirmar_reagendamento` when awaiting confirmation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685db1d89b208327b88cf9656dcf432f