### PR TITLE
Improve confirmation handling

### DIFF
--- a/__tests__/dialogflowWebhookController.manualAgendamento.test.js
+++ b/__tests__/dialogflowWebhookController.manualAgendamento.test.js
@@ -1,0 +1,101 @@
+jest.mock('../services/twilioService', () => ({
+  sendWhatsApp: jest.fn(() => Promise.resolve({ sid: '1' })),
+  waitForDelivery: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('../controllers/clienteController', () => ({
+  encontrarOuCriarCliente: jest.fn(() => Promise.resolve({ id: 10, nome: 'Jose', telefone: '+5511999999999' })),
+  atualizarNomeCliente: jest.fn(),
+  buscarClientePorTelefone: jest.fn(),
+}));
+
+jest.mock('@google-cloud/dialogflow', () => {
+  const detectIntentMock = jest.fn();
+  return {
+    __detectIntentMock: detectIntentMock,
+    SessionsClient: jest.fn().mockImplementation(() => ({
+      projectAgentSessionPath: jest.fn(() => 'path'),
+      detectIntent: detectIntentMock,
+    })),
+  };
+});
+const { __detectIntentMock: detectIntentMock } = require('@google-cloud/dialogflow');
+
+jest.mock('../controllers/agendamentoController', () => ({
+  agendarServico: jest.fn(),
+}));
+
+const { handleWebhook, __test } = require('../controllers/dialogflowWebhookController');
+const { agendamentosPendentes } = __test;
+
+describe('manual agendamento via webhook', () => {
+  beforeEach(() => {
+    agendamentosPendentes.clear();
+    jest.clearAllMocks();
+    detectIntentMock.mockResolvedValue([
+      {
+        queryResult: {
+          intent: { displayName: 'confirmar_agendamento' },
+          parameters: { fields: {} },
+          fulfillmentText: '',
+          outputContexts: [],
+        },
+      },
+    ]);
+  });
+
+  test('sim confirma agendamento e limpa estado', async () => {
+    const { agendarServico } = require('../controllers/agendamentoController');
+    agendarServico.mockResolvedValue({ success: true });
+
+    agendamentosPendentes.set('user', {
+      confirmationStep: 'awaiting_confirm',
+      servico: 'Corte',
+      servicoId: 1,
+      diaEscolhido: '2030-01-01',
+      horarioEscolhido: '09:00',
+      clienteId: 10,
+    });
+
+    const req = { body: { Body: 'sim', From: 'user', ProfileName: 'Jose' } };
+    const res = { json: jest.fn(), status: jest.fn(() => res) };
+
+    await handleWebhook(req, res);
+
+    expect(agendarServico).toHaveBeenCalled();
+    expect(agendamentosPendentes.has('user')).toBe(false);
+  });
+
+  test('confirma agendamento mesmo com intent incorreta', async () => {
+    const { agendarServico } = require('../controllers/agendamentoController');
+    agendarServico.mockResolvedValue({ success: true });
+
+    agendamentosPendentes.set('user', {
+      confirmationStep: 'awaiting_confirm',
+      servico: 'Corte',
+      servicoId: 1,
+      diaEscolhido: '2030-01-01',
+      horarioEscolhido: '09:00',
+      clienteId: 10,
+    });
+
+    detectIntentMock.mockResolvedValueOnce([
+      {
+        queryResult: {
+          intent: { displayName: 'confirmar_inicio_reagendamento' },
+          parameters: { fields: {} },
+          fulfillmentText: '',
+          outputContexts: [],
+        },
+      },
+    ]);
+
+    const req = { body: { Body: 'confirmar', From: 'user', ProfileName: 'Jose' } };
+    const res = { json: jest.fn(), status: jest.fn(() => res) };
+
+    await handleWebhook(req, res);
+
+    expect(agendarServico).toHaveBeenCalled();
+    expect(agendamentosPendentes.has('user')).toBe(false);
+  });
+});

--- a/controllers/dialogflowWebhookController.js
+++ b/controllers/dialogflowWebhookController.js
@@ -314,6 +314,7 @@ async function handleEscolhaDataHora({ from, msg, parametros }) {
 
     estado.horarioEscolhido = hora;
     estado.confirmationStep = 'awaiting_confirm';
+    estado.contextoDialogflow = 'aguardando_confirmacao_agendamento';
     setEstado(from, estado);
 
     const resumo = formatarDataHorarioBr(`${estado.diaEscolhido}T${hora}:00`);
@@ -336,6 +337,7 @@ async function handleInformarNovoNome({ from, msg }) {
   if (clienteAtualizado) {
     estado.nome = clienteAtualizado.nome;
     estado.confirmationStep = 'awaiting_confirm';
+    estado.contextoDialogflow = 'aguardando_confirmacao_agendamento';
     setEstado(from, estado);
     return `Nome atualizado para *${nome}*. Confirma o agendamento?`;
   }
@@ -764,6 +766,13 @@ async function handleWebhook(req, res) {
     intent = 'confirmar_reagendamento';
   }
 
+  if (
+    estado.confirmationStep === 'awaiting_confirm' &&
+    intent === 'default'
+  ) {
+    intent = 'confirmar_agendamento';
+  }
+
   // Corrige casos em que o Dialogflow identifica erroneamente como
   // 'confirmar_inicio_reagendamento' na etapa final de confirmação
   if (
@@ -771,6 +780,13 @@ async function handleWebhook(req, res) {
     intent === 'confirmar_inicio_reagendamento'
   ) {
     intent = 'confirmar_reagendamento';
+  }
+
+  if (
+    estado.confirmationStep === 'awaiting_confirm' &&
+    (intent === 'confirmar_inicio_reagendamento' || intent === 'confirmar_reagendamento')
+  ) {
+    intent = 'confirmar_agendamento';
   }
 
   if (!intentNoFluxo(intent, estado.fluxo)) {

--- a/dialogflow/intents/confirmar_agendamento.json
+++ b/dialogflow/intents/confirmar_agendamento.json
@@ -1,0 +1,15 @@
+{
+  "displayName": "confirmar_agendamento",
+  "priority": 500000,
+  "trainingPhrases": [
+    { "type": "EXAMPLE", "parts": [ { "text": "sim" } ] },
+    { "type": "EXAMPLE", "parts": [ { "text": "ok" } ] },
+    { "type": "EXAMPLE", "parts": [ { "text": "pode ser" } ] },
+    { "type": "EXAMPLE", "parts": [ { "text": "confirmar" } ] },
+    { "type": "EXAMPLE", "parts": [ { "text": "confirmado" } ] }
+  ],
+  "inputContextNames": [
+    "aguardando_confirmacao_agendamento"
+  ],
+  "outputContexts": []
+}


### PR DESCRIPTION
## Summary
- create intent `confirmar_agendamento` with its own context
- track `aguardando_confirmacao_agendamento` in webhook
- force intent to `confirmar_agendamento` when context requires it
- add unit tests covering agendamento confirmation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e9c1106108327b7e7a78de612aa9f