### PR TITLE
Fix reschedule context persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ reservai_twilio.json
 package-lock.json
 barbearia-calendar.json
 logs/
+sessionStore.json

--- a/__tests__/dialogflowWebhookController.manualAgendamento.test.js
+++ b/__tests__/dialogflowWebhookController.manualAgendamento.test.js
@@ -26,11 +26,11 @@ jest.mock('../controllers/agendamentoController', () => ({
 }));
 
 const { handleWebhook, __test } = require('../controllers/dialogflowWebhookController');
-const { agendamentosPendentes } = __test;
+const { sessionStore } = __test;
 
 describe('manual agendamento via webhook', () => {
   beforeEach(() => {
-    agendamentosPendentes.clear();
+    Object.keys(sessionStore._store).forEach(k => delete sessionStore._store[k]);
     jest.clearAllMocks();
     detectIntentMock.mockResolvedValue([
       {
@@ -48,7 +48,7 @@ describe('manual agendamento via webhook', () => {
     const { agendarServico } = require('../controllers/agendamentoController');
     agendarServico.mockResolvedValue({ success: true });
 
-    agendamentosPendentes.set('user', {
+    sessionStore.set('user', {
       confirmationStep: 'awaiting_confirm',
       servico: 'Corte',
       servicoId: 1,
@@ -63,14 +63,14 @@ describe('manual agendamento via webhook', () => {
     await handleWebhook(req, res);
 
     expect(agendarServico).toHaveBeenCalled();
-    expect(agendamentosPendentes.has('user')).toBe(false);
+    expect(sessionStore.has('user')).toBe(false);
   });
 
   test('confirma agendamento mesmo com intent incorreta', async () => {
     const { agendarServico } = require('../controllers/agendamentoController');
     agendarServico.mockResolvedValue({ success: true });
 
-    agendamentosPendentes.set('user', {
+    sessionStore.set('user', {
       confirmationStep: 'awaiting_confirm',
       servico: 'Corte',
       servicoId: 1,
@@ -96,6 +96,6 @@ describe('manual agendamento via webhook', () => {
     await handleWebhook(req, res);
 
     expect(agendarServico).toHaveBeenCalled();
-    expect(agendamentosPendentes.has('user')).toBe(false);
+    expect(sessionStore.has('user')).toBe(false);
   });
 });

--- a/__tests__/dialogflowWebhookController.manualReagendamento.test.js
+++ b/__tests__/dialogflowWebhookController.manualReagendamento.test.js
@@ -32,11 +32,11 @@ jest.mock('../services/calendarService', () => ({
 }));
 
 const { handleWebhook, __test } = require('../controllers/dialogflowWebhookController');
-const { agendamentosPendentes } = __test;
+const { sessionStore } = __test;
 
 describe('manual reagendamento via webhook', () => {
   beforeEach(() => {
-    agendamentosPendentes.clear();
+    Object.keys(sessionStore._store).forEach(k => delete sessionStore._store[k]);
     jest.clearAllMocks();
     detectIntentMock.mockResolvedValue([
       {
@@ -56,7 +56,7 @@ describe('manual reagendamento via webhook', () => {
   });
 
   test('numero seleciona agendamento e avanca estado', async () => {
-    agendamentosPendentes.set('user', {
+    sessionStore.set('user', {
       fluxo: 'reagendamento',
       confirmationStep: 'awaiting_reagendamento',
       agendamentos: [
@@ -71,7 +71,7 @@ describe('manual reagendamento via webhook', () => {
     await handleWebhook(req, res);
 
     expect(require('../services/twilioService').sendWhatsApp).toHaveBeenCalled();
-    const estado = agendamentosPendentes.get('user');
+    const estado = sessionStore.get('user');
     expect(estado.confirmationStep).toBe('awaiting_reagendamento_time');
   });
 
@@ -79,7 +79,7 @@ describe('manual reagendamento via webhook', () => {
     const { reagendarAgendamento } = require('../controllers/gerenciamentoController');
     reagendarAgendamento.mockResolvedValue({ success: true });
 
-    agendamentosPendentes.set('user', {
+    sessionStore.set('user', {
       fluxo: 'reagendamento',
       confirmationStep: 'awaiting_reagendamento_confirm',
       agendamentoId: 1,
@@ -106,14 +106,14 @@ describe('manual reagendamento via webhook', () => {
     await handleWebhook(req, res);
 
     expect(reagendarAgendamento).toHaveBeenCalledWith(1, '2030-01-02T09:00:00-03:00', 'g1', 10);
-    expect(agendamentosPendentes.has('user')).toBe(false);
+    expect(sessionStore.has('user')).toBe(false);
   });
 
   test('confirma reagendamento mesmo com intent incorreta', async () => {
     const { reagendarAgendamento } = require('../controllers/gerenciamentoController');
     reagendarAgendamento.mockResolvedValue({ success: true });
 
-    agendamentosPendentes.set('user', {
+    sessionStore.set('user', {
       fluxo: 'reagendamento',
       confirmationStep: 'awaiting_reagendamento_confirm',
       agendamentoId: 1,
@@ -140,6 +140,6 @@ describe('manual reagendamento via webhook', () => {
     await handleWebhook(req, res);
 
     expect(reagendarAgendamento).toHaveBeenCalledWith(1, '2030-01-02T09:00:00-03:00', 'g1', 10);
-    expect(agendamentosPendentes.has('user')).toBe(false);
+    expect(sessionStore.has('user')).toBe(false);
   });
 });

--- a/controllers/dialogflowWebhookController.js
+++ b/controllers/dialogflowWebhookController.js
@@ -42,7 +42,7 @@ const sessionClient = new dialogflow.SessionsClient({
 });
 const projectId = process.env.DIALOGFLOW_PROJECT_ID;
 
-const agendamentosPendentes = new Map();
+const sessionStore = require('../services/sessionStore');
 
 const FLUXO_INTENTS = {
   reagendamento: new Set([
@@ -59,13 +59,13 @@ const FLUXO_INTENTS = {
 };
 
 function getEstado(from) {
-  return agendamentosPendentes.get(from) || {};
+  return sessionStore.get(from) || {};
 }
 
 function setEstado(from, updates) {
-  const atual = agendamentosPendentes.get(from) || {};
+  const atual = sessionStore.get(from) || {};
   const novo = { ...atual, ...updates };
-  agendamentosPendentes.set(from, novo);
+  sessionStore.set(from, novo);
   return novo;
 }
 
@@ -116,7 +116,7 @@ function listarPrimeirosDias(diasMap, start = 0, count = 6) {
 
 /** Envia saudação inicial e reseta o estado do usuário */
 async function handleWelcome({ from }) {
-  agendamentosPendentes.delete(from);
+  sessionStore.del(from);
   return mensagens.BEM_VINDO;
 }
 
@@ -152,7 +152,7 @@ async function handleEscolhaServico({ from, parametros }) {
 
 /** Processa a escolha do dia e horário evitando domingos */
 async function handleEscolhaDataHora({ from, msg, parametros }) {
-  const estado = agendamentosPendentes.get(from);
+  const estado = sessionStore.get(from);
   if (!estado || !estado.servico) return mensagens.ESCOLHA_SERVICO_PRIMEIRO;
   logger.info(from, `handleEscolhaDataHora - step ${estado.confirmationStep} servico=${estado.servico}`);
   if (estado.confirmationStep === 'awaiting_reagendamento_time') {
@@ -332,9 +332,9 @@ async function handleEscolhaDataHora({ from, msg, parametros }) {
 
 /** Recebe o nome do cliente para atualização */
 async function handleInformarNovoNome({ from, msg }) {
-  const estado = agendamentosPendentes.get(from);
+  const estado = sessionStore.get(from);
   if (!estado || estado.confirmationStep !== 'awaiting_name') {
-    agendamentosPendentes.delete(from);
+    sessionStore.del(from);
     return mensagens.NAO_ESPERANDO_NOME;
   }
   const nome = msg.trim();
@@ -352,7 +352,7 @@ async function handleInformarNovoNome({ from, msg }) {
 
 /** Confirma o agendamento após validar dados obrigatórios */
 async function handleConfirmarAgendamento({ from }) {
-  const estado = agendamentosPendentes.get(from);
+  const estado = sessionStore.get(from);
   if (!estado || estado.confirmationStep !== 'awaiting_confirm')
     return mensagens.AGENDAMENTO_NAO_CONFIRMADO;
 
@@ -370,7 +370,7 @@ async function handleConfirmarAgendamento({ from }) {
     horario: `${estado.diaEscolhido}T${estado.horarioEscolhido}:00`,
   });
 
-  agendamentosPendentes.delete(from);
+  sessionStore.del(from);
 
   if (!result.success) return mensagens.ERRO_AGENDAR;
   return `✅ Agendamento confirmado para *${estado.servico}* em *${formatarDataHorarioBr(`${estado.diaEscolhido}T${estado.horarioEscolhido}:00`)}* no nome de *${estado.nome}*.` +
@@ -400,7 +400,7 @@ async function handleCancelamento({ from }) {
 
 /** Seleciona qual agendamento será cancelado */
 async function handleSelecionarCancelamento({ from, msg }) {
-  const estado = agendamentosPendentes.get(from);
+  const estado = sessionStore.get(from);
   if (!estado || estado.confirmationStep !== 'awaiting_cancelar')
     return mensagens.NENHUM_CANCELAMENTO;
   const idx = parseInt(msg) - 1;
@@ -416,11 +416,11 @@ async function handleSelecionarCancelamento({ from, msg }) {
 
 /** Confirma ou aborta o cancelamento escolhido */
 async function handleConfirmarCancelamento({ from, msg }) {
-  const estado = agendamentosPendentes.get(from);
+  const estado = sessionStore.get(from);
   if (!estado || estado.confirmationStep !== 'awaiting_cancel_confirm')
     return mensagens.NENHUM_CANCELAMENTO;
   if (!/^(sim|ok|pode ser|confirmar|confirmado)/i.test(msg)) {
-    agendamentosPendentes.delete(from);
+    sessionStore.del(from);
     return mensagens.CANCELAMENTO_NAO_CONFIRMADO;
   }
   const result = await cancelarAgendamento(
@@ -428,7 +428,7 @@ async function handleConfirmarCancelamento({ from, msg }) {
     estado.eventId,
     estado.clienteId
   );
-  agendamentosPendentes.delete(from);
+  sessionStore.del(from);
   if (!result.success) return mensagens.ERRO_PROCESSAR_CANCELAMENTO;
   return `✅ Agendamento cancelado com sucesso!`;
 }
@@ -459,7 +459,7 @@ async function handleReagendar({ from }) {
 
 /** Confirma o agendamento a ser reagendado */
 async function handleConfirmarInicioReagendamento({ from, msg }) {
-  const estado = agendamentosPendentes.get(from);
+  const estado = sessionStore.get(from);
   if (!estado || estado.confirmationStep !== 'awaiting_reagendamento') {
     return mensagens.NENHUM_REAGENDAMENTO;
   }
@@ -494,7 +494,7 @@ async function handleConfirmarInicioReagendamento({ from, msg }) {
 
 /** Recebe a nova data e hora para o reagendamento */
 async function handleEscolhaDataHoraReagendamento({ from, msg, parametros }) {
-  const estado = agendamentosPendentes.get(from);
+  const estado = sessionStore.get(from);
   if (!estado) return mensagens.NENHUM_REAGENDAMENTO;
 
   if (estado.confirmationStep === 'awaiting_reagendamento_time' && !estado.novoDia) {
@@ -603,12 +603,12 @@ async function handleEscolhaDataHoraReagendamento({ from, msg, parametros }) {
 
 /** Finaliza o reagendamento se confirmado */
 async function handleConfirmarReagendamento({ from, msg }) {
-  const estado = agendamentosPendentes.get(from);
+  const estado = sessionStore.get(from);
   if (!estado || estado.confirmationStep !== 'awaiting_reagendamento_confirm')
     return mensagens.NENHUM_REAGENDAMENTO;
   logger.info(from, `Confirmando reagendamento do servico ${estado.servico} para ${estado.novoHorario}`);
   if (!/^(sim|ok|pode ser|confirmar|confirmado)/i.test(msg)) {
-    agendamentosPendentes.delete(from);
+    sessionStore.del(from);
     return mensagens.REAGENDAMENTO_CANCELADO;
   }
   const result = await reagendarAgendamento(
@@ -617,14 +617,14 @@ async function handleConfirmarReagendamento({ from, msg }) {
     estado.eventId,
     estado.clienteId
   );
-  agendamentosPendentes.delete(from);
+  sessionStore.del(from);
   if (!result.success) return mensagens.ERRO_REAGENDAR;
   return `✅ Horário atualizado! ${estado.servico} agora está marcado para ${formatarDataHorarioBr(estado.novoHorario)}.`;
 }
 
 /** Fallback para intents não mapeadas */
 async function handleDefault({ from, fulfillment }) {
-  const estado = agendamentosPendentes.get(from);
+  const estado = sessionStore.get(from);
   if (estado) {
     switch (estado.confirmationStep) {
       case 'awaiting_day': {
@@ -713,13 +713,13 @@ async function handleWebhook(req, res) {
   logger.user(from, msg);
 
   const texto = (msg || '').trim().toLowerCase();
-  if (/^\d+$/.test(texto) && !agendamentosPendentes.has(from)) {
+  if (/^\d+$/.test(texto) && !sessionStore.has(from)) {
     const reply = mensagens.NAO_ENTENDI;
     logger.bot(from, reply);
     return res.json(createResponse(true, { reply }, null));
   }
   if (/^(cancelar|voltar|reiniciar)/.test(texto)) {
-    agendamentosPendentes.delete(from);
+    sessionStore.del(from);
     const respostaReinicio = await handleWelcome({ from });
     logger.bot(from, respostaReinicio);
     return res.json(createResponse(true, { reply: respostaReinicio }, null));
@@ -834,7 +834,7 @@ async function handleWebhook(req, res) {
 module.exports = {
   handleWebhook,
   __test: {
-    agendamentosPendentes,
+    sessionStore,
     handleConfirmarInicioReagendamento,
   },
 };

--- a/services/sessionStore.js
+++ b/services/sessionStore.js
@@ -1,0 +1,45 @@
+const fs = require('fs');
+const path = require('path');
+
+const filePath = path.join(__dirname, '..', 'sessionStore.json');
+
+let store = {};
+try {
+  if (fs.existsSync(filePath)) {
+    store = JSON.parse(fs.readFileSync(filePath, 'utf8')) || {};
+  }
+} catch (e) {
+  store = {};
+}
+
+function save() {
+  try {
+    fs.writeFileSync(filePath, JSON.stringify(store, null, 2));
+  } catch (e) {
+    // ignore
+  }
+}
+
+function get(id) {
+  return store[id];
+}
+
+function set(id, updates) {
+  const current = store[id] || {};
+  store[id] = { ...current, ...updates };
+  save();
+  return store[id];
+}
+
+function del(id) {
+  if (store[id]) {
+    delete store[id];
+    save();
+  }
+}
+
+function has(id) {
+  return Object.prototype.hasOwnProperty.call(store, id);
+}
+
+module.exports = { get, set, del, has, _store: store };


### PR DESCRIPTION
## Summary
- persist user state using a JSON-backed session store
- adapt webhook controller to use sessionStore instead of an in-memory map
- expose sessionStore for tests and update tests accordingly
- ignore generated session file in git

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ebf8d8904832780213b3d3ab26ae3