### PR TITLE
Improve Dialogflow training phrases

### DIFF
--- a/dialogflow/intents/confirmar_reagendamento.json
+++ b/dialogflow/intents/confirmar_reagendamento.json
@@ -2,11 +2,62 @@
   "displayName": "confirmar_reagendamento",
   "priority": 500000,
   "trainingPhrases": [
-    { "type": "EXAMPLE", "parts": [ { "text": "sim" } ] },
-    { "type": "EXAMPLE", "parts": [ { "text": "ok" } ] },
-    { "type": "EXAMPLE", "parts": [ { "text": "pode ser" } ] },
-    { "type": "EXAMPLE", "parts": [ { "text": "confirmar" } ] },
-    { "type": "EXAMPLE", "parts": [ { "text": "confirmado" } ] }
+    {
+      "type": "EXAMPLE",
+      "parts": [
+        {
+          "text": "sim"
+        }
+      ]
+    },
+    {
+      "type": "EXAMPLE",
+      "parts": [
+        {
+          "text": "ok"
+        }
+      ]
+    },
+    {
+      "type": "EXAMPLE",
+      "parts": [
+        {
+          "text": "pode ser"
+        }
+      ]
+    },
+    {
+      "type": "EXAMPLE",
+      "parts": [
+        {
+          "text": "confirmar"
+        }
+      ]
+    },
+    {
+      "type": "EXAMPLE",
+      "parts": [
+        {
+          "text": "confirmado"
+        }
+      ]
+    },
+    {
+      "type": "EXAMPLE",
+      "parts": [
+        {
+          "text": "sim, reagendar"
+        }
+      ]
+    },
+    {
+      "type": "EXAMPLE",
+      "parts": [
+        {
+          "text": "confirmar reagendamento"
+        }
+      ]
+    }
   ],
   "inputContextNames": [
     "aguardando_confirmacao_reagendamento"

--- a/dialogflow/intents/escolha_datahora_reagendamento.json
+++ b/dialogflow/intents/escolha_datahora_reagendamento.json
@@ -2,22 +2,154 @@
   "displayName": "escolha_datahora_reagendamento",
   "priority": 500000,
   "trainingPhrases": [
-    { "type": "EXAMPLE", "parts": [ { "text": "amanhã 15h" } ] },
-    { "type": "EXAMPLE", "parts": [ { "text": "sexta 10:00" } ] },
-    { "type": "EXAMPLE", "parts": [ { "text": "1", "entityType": "@sys.number", "alias": "opcao" } ] },
-    { "type": "EXAMPLE", "parts": [ { "text": "2", "entityType": "@sys.number", "alias": "opcao" } ] },
-    { "type": "EXAMPLE", "parts": [ { "text": "segunda" } ] },
-    { "type": "EXAMPLE", "parts": [ { "text": "segunda-feira" } ] },
-    { "type": "EXAMPLE", "parts": [ { "text": "terca" } ] },
-    { "type": "EXAMPLE", "parts": [ { "text": "terça-feira" } ] },
-    { "type": "EXAMPLE", "parts": [ { "text": "quarta" } ] },
-    { "type": "EXAMPLE", "parts": [ { "text": "quarta-feira" } ] },
-    { "type": "EXAMPLE", "parts": [ { "text": "quinta" } ] },
-    { "type": "EXAMPLE", "parts": [ { "text": "quinta-feira" } ] },
-    { "type": "EXAMPLE", "parts": [ { "text": "sexta" } ] },
-    { "type": "EXAMPLE", "parts": [ { "text": "sexta-feira" } ] },
-    { "type": "EXAMPLE", "parts": [ { "text": "sabado" } ] },
-    { "type": "EXAMPLE", "parts": [ { "text": "sábado" } ] }
+    {
+      "type": "EXAMPLE",
+      "parts": [
+        {
+          "text": "amanhã 15h"
+        }
+      ]
+    },
+    {
+      "type": "EXAMPLE",
+      "parts": [
+        {
+          "text": "sexta 10:00"
+        }
+      ]
+    },
+    {
+      "type": "EXAMPLE",
+      "parts": [
+        {
+          "text": "1",
+          "entityType": "@sys.number",
+          "alias": "opcao"
+        }
+      ]
+    },
+    {
+      "type": "EXAMPLE",
+      "parts": [
+        {
+          "text": "2",
+          "entityType": "@sys.number",
+          "alias": "opcao"
+        }
+      ]
+    },
+    {
+      "type": "EXAMPLE",
+      "parts": [
+        {
+          "text": "segunda"
+        }
+      ]
+    },
+    {
+      "type": "EXAMPLE",
+      "parts": [
+        {
+          "text": "segunda-feira"
+        }
+      ]
+    },
+    {
+      "type": "EXAMPLE",
+      "parts": [
+        {
+          "text": "terca"
+        }
+      ]
+    },
+    {
+      "type": "EXAMPLE",
+      "parts": [
+        {
+          "text": "terça-feira"
+        }
+      ]
+    },
+    {
+      "type": "EXAMPLE",
+      "parts": [
+        {
+          "text": "quarta"
+        }
+      ]
+    },
+    {
+      "type": "EXAMPLE",
+      "parts": [
+        {
+          "text": "quarta-feira"
+        }
+      ]
+    },
+    {
+      "type": "EXAMPLE",
+      "parts": [
+        {
+          "text": "quinta"
+        }
+      ]
+    },
+    {
+      "type": "EXAMPLE",
+      "parts": [
+        {
+          "text": "quinta-feira"
+        }
+      ]
+    },
+    {
+      "type": "EXAMPLE",
+      "parts": [
+        {
+          "text": "sexta"
+        }
+      ]
+    },
+    {
+      "type": "EXAMPLE",
+      "parts": [
+        {
+          "text": "sexta-feira"
+        }
+      ]
+    },
+    {
+      "type": "EXAMPLE",
+      "parts": [
+        {
+          "text": "sabado"
+        }
+      ]
+    },
+    {
+      "type": "EXAMPLE",
+      "parts": [
+        {
+          "text": "sábado"
+        }
+      ]
+    },
+    {
+      "type": "EXAMPLE",
+      "parts": [
+        {
+          "text": "hoje"
+        }
+      ]
+    },
+    {
+      "type": "EXAMPLE",
+      "parts": [
+        {
+          "text": "amanhã"
+        }
+      ]
+    }
   ],
   "parameters": [
     {
@@ -49,6 +181,9 @@
     "reagendamento_datahora_selected"
   ],
   "outputContexts": [
-    { "name": "reagendamento_datahora_selected", "lifespanCount": 5 }
+    {
+      "name": "reagendamento_datahora_selected",
+      "lifespanCount": 5
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- expand training phrases to handle common day expressions
- add explicit confirmations for rescheduling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ec577eef08327aa9ccd7035ad8675