### PR TITLE
Fix Dialogflow intents for rescheduling

### DIFF
--- a/dialogflow/intents/confirmar_inicio_reagendamento.json
+++ b/dialogflow/intents/confirmar_inicio_reagendamento.json
@@ -2,44 +2,16 @@
   "displayName": "confirmar_inicio_reagendamento",
   "priority": 500000,
   "trainingPhrases": [
-    {
-      "type": "EXAMPLE",
-      "parts": [
-        { "text": "1", "entityType": "@sys.number", "alias": "escolha" }
-      ]
-    },
-    {
-      "type": "EXAMPLE",
-      "parts": [
-        { "text": "2", "entityType": "@sys.number", "alias": "escolha" }
-      ]
-    },
-    {
-      "type": "EXAMPLE",
-      "parts": [
-        { "text": "3", "entityType": "@sys.number", "alias": "escolha" }
-      ]
-    },
-    {
-      "type": "EXAMPLE",
-      "parts": [
-        {
-          "text": "Quero a opção 4",
-          "entityType": "@sys.number",
-          "alias": "escolha"
-        }
-      ]
-    },
-    { "type": "EXAMPLE", "parts": [{ "text": "sexta 10h" }] },
-    { "type": "EXAMPLE", "parts": [{ "text": "amanhã 14:00" }] }
-  ],
-  "parameters": [
-    {
-      "id": "escolha",
-      "entityType": "@sys.number",
-      "alias": "escolha",
-      "isList": false
-    }
+    { "type": "EXAMPLE", "parts": [ { "text": "1" } ] },
+    { "type": "EXAMPLE", "parts": [ { "text": "2" } ] },
+    { "type": "EXAMPLE", "parts": [ { "text": "3" } ] },
+    { "type": "EXAMPLE", "parts": [ { "text": "4" } ] },
+    { "type": "EXAMPLE", "parts": [ { "text": "5" } ] },
+    { "type": "EXAMPLE", "parts": [ { "text": "6" } ] },
+    { "type": "EXAMPLE", "parts": [ { "text": "7" } ] },
+    { "type": "EXAMPLE", "parts": [ { "text": "8" } ] },
+    { "type": "EXAMPLE", "parts": [ { "text": "9" } ] },
+    { "type": "EXAMPLE", "parts": [ { "text": "10" } ] }
   ],
   "inputContextNames": ["reagendamento_awaiting_datahora"],
   "outputContexts": [

--- a/dialogflow/intents/confirmar_reagendamento.json
+++ b/dialogflow/intents/confirmar_reagendamento.json
@@ -1,0 +1,12 @@
+{
+  "displayName": "confirmar_reagendamento",
+  "priority": 500000,
+  "trainingPhrases": [
+    { "type": "EXAMPLE", "parts": [ { "text": "Sim" } ] },
+    { "type": "EXAMPLE", "parts": [ { "text": "Confirmar" } ] },
+    { "type": "EXAMPLE", "parts": [ { "text": "Não" } ] },
+    { "type": "EXAMPLE", "parts": [ { "text": "Pode ser" } ] }
+  ],
+  "inputContextNames": ["aguardando_confirmacao_reagendamento"],
+  "outputContexts": []
+}

--- a/dialogflow/intents/escolha_datahora_reagendamento.json
+++ b/dialogflow/intents/escolha_datahora_reagendamento.json
@@ -1,0 +1,16 @@
+{
+  "displayName": "escolha_datahora_reagendamento",
+  "priority": 500000,
+  "trainingPhrases": [
+    { "type": "EXAMPLE", "parts": [ { "text": "segunda" } ] },
+    { "type": "EXAMPLE", "parts": [ { "text": "terça" } ] },
+    { "type": "EXAMPLE", "parts": [ { "text": "quarta" } ] },
+    { "type": "EXAMPLE", "parts": [ { "text": "quinta" } ] },
+    { "type": "EXAMPLE", "parts": [ { "text": "sexta" } ] },
+    { "type": "EXAMPLE", "parts": [ { "text": "sábado" } ] }
+  ],
+  "inputContextNames": ["reagendamento_datahora_selected"],
+  "outputContexts": [
+    { "name": "aguardando_confirmacao_reagendamento", "lifespanCount": 5 }
+  ]
+}


### PR DESCRIPTION
## Summary
- update `confirmar_inicio_reagendamento` intent to only use numeric phrases
- add missing intents for `escolha_datahora_reagendamento` and `confirmar_reagendamento`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686443178f1c8327ac9f6c9cac5bb5e4